### PR TITLE
chore(governance): community health files, badges, schema version

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Every file in this repository is owned by the maintainer until other
+# contributors earn family-level ownership through sustained, correct
+# contributions. See .github/CONTRIBUTING.md.
+
+* @mjmirza

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,51 @@
+<!-- freshness: frozen -->
+
+# Code of Conduct
+
+## Our pledge
+
+We want this catalogue to stay a place where a correction is welcome and a
+disagreement stays about the technical claim, not the person who raised it.
+Contributors and maintainers pledge to make participation harassment free for
+everyone, regardless of age, body size, visible or invisible disability,
+ethnicity, sex characteristics, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Standards
+
+Behavior that helps this project:
+
+- Disagreeing with a claim by pointing at a source, a benchmark, or a
+  production counter-example.
+- Accepting a correction gracefully, and thanking the person who found it.
+- Focusing feedback on the entry, the citation, or the code sample, never on
+  the contributor.
+
+Behavior that does not belong here:
+
+- Personal attacks, insults, or dismissive language directed at a contributor.
+- Publishing someone else's private information without consent.
+- Sustained disruption of an issue, a pull request, or a discussion thread.
+
+## Enforcement
+
+Maintainers are responsible for clarifying and enforcing this standard, and
+will remove, edit, or reject comments, commits, code, issues, and other
+contributions that are not aligned with it.
+
+Report unacceptable behavior by opening a private security advisory (see
+`.github/SECURITY.md`) or by contacting a maintainer listed in
+`.github/CODEOWNERS` directly. Every report is reviewed and investigated, and
+a response is given as soon as reasonably possible.
+
+## Scope
+
+This applies within all project spaces (issues, pull requests, discussions,
+code review) and in public spaces when an individual is representing the
+project.
+
+## Attribution
+
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+<!-- freshness: frozen -->
+
+# Contributing
+
+Every entry in this catalogue carries the eighteen dimensions defined in
+`docs/ENTRY-TEMPLATE.md`, and every claim traces to a citation that resolves.
+That bar applies equally to a maintainer's own pull request and to a first
+time contributor's. Nothing merges by exception.
+
+## Before you open a pull request
+
+1. Read `docs/ENTRY-TEMPLATE.md`. It is the schema, not a suggestion.
+2. Check `docs/AUTHORING-QUEUE.json` and the family README under
+   `patterns/<family>/README.md` so a new entry does not duplicate one
+   already published or already queued.
+3. Run the local gates before you push, the same four gates CI runs:
+
+   ```
+   python3 tools/check-structure.py
+   python3 tools/check-prose.py
+   python3 tools/check-code.py --strict
+   python3 tools/validate-refs.py --strict
+   npx --yes markdownlint-cli2@0.23.2 "patterns/**/*.md" "docs/**/*.md" README.md
+   ```
+
+4. If you touch `docs/AUTHORING-QUEUE.json` or add a published entry, also
+   run `python3 tools/gen-indexes.py` and
+   `python3 tools/gen-catalogue-status.py`, and commit the files they
+   regenerate (family `README.md`, `docs/PROGRESS.md`, `dist/`, the root
+   `README.md` badges and table) in the same commit. A stale catalogue status
+   is caught in CI and blocks the merge.
+
+## What a pull request needs
+
+- One branch per change, off `main`.
+- All eighteen dimensions present, per `docs/ENTRY-TEMPLATE.md`, for a new
+  entry, or a clearly scoped fix for anything else (a correction, a citation
+  repair, a code fix).
+- Every claim in prose either self-evidently true from the code sample shown,
+  or backed by a citation in the References section that a reader can follow.
+- No invented statistics, no invented production-use claims, no invented
+  vendor names. If you cannot cite it, do not claim it.
+- Original prose. Do not paste from a textbook or a vendor doc; write the
+  explanation in your own words and cite the source you learned it from.
+
+## What kinds of contributions are welcome
+
+- A new pattern entry from the authoring queue, or a new family the queue is
+  missing (open an issue with the `new-pattern` template first if the family
+  does not exist yet).
+- A factual correction to a published entry (`factual-correction` template).
+- A citation repair for a link that has gone dead (`citation-problem` or
+  `broken-reference` template).
+- A duplicate or overlapping entry flag (`duplicate-pattern` template).
+- A production-use claim that needs a source or needs retracting
+  (`production-use-correction` template).
+
+## Review
+
+Every pull request goes through CI (structure, prose, code compile,
+citations, markdown style) before a maintainer reviews it. A red CI is never
+merged. See `.github/PULL_REQUEST_TEMPLATE.md` for what the description
+should contain.
+
+## License
+
+By contributing, you agree your contribution is licensed under this
+repository's CC BY 4.0 license (see `LICENSE`), and that you have the right to
+license it that way.

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# These are supported funding model platforms
+github: mjmirza

--- a/.github/ISSUE_TEMPLATE/attribution-concern.yml
+++ b/.github/ISSUE_TEMPLATE/attribution-concern.yml
@@ -1,0 +1,24 @@
+name: Attribution concern
+description: Prose or a code sample looks copied rather than original, or a source is uncredited.
+title: "[attribution]: "
+labels: ["attribution"]
+body:
+  - type: input
+    id: entry
+    attributes:
+      label: Entry
+    validations:
+      required: true
+  - type: input
+    id: source
+    attributes:
+      label: The source you believe it was copied from
+    validations:
+      required: true
+  - type: textarea
+    id: detail
+    attributes:
+      label: What matches
+      description: Quote the overlapping text or code, and where it appears in the source.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/broken-reference.yml
+++ b/.github/ISSUE_TEMPLATE/broken-reference.yml
@@ -1,0 +1,29 @@
+name: Broken reference link
+description: A citation URL no longer resolves (404, moved, domain gone).
+title: "[broken link]: "
+labels: ["broken-reference"]
+body:
+  - type: input
+    id: entry
+    attributes:
+      label: Entry
+      description: Path to the entry.
+    validations:
+      required: true
+  - type: input
+    id: url
+    attributes:
+      label: The dead URL
+    validations:
+      required: true
+  - type: input
+    id: replacement
+    attributes:
+      label: A live replacement, if you found one
+      description: Prefer a Wayback Machine snapshot or a confirmed-live current URL over deleting the citation.
+  - type: markdown
+    attributes:
+      value: |
+        This repository never deletes or fabricates a citation to fix a broken
+        link. If you cannot find a live replacement, say so and a maintainer
+        will look for one via the Wayback Machine before removing anything.

--- a/.github/ISSUE_TEMPLATE/citation-problem.yml
+++ b/.github/ISSUE_TEMPLATE/citation-problem.yml
@@ -1,0 +1,29 @@
+name: Citation problem
+description: A cited source does not actually support the claim it is attached to.
+title: "[citation]: "
+labels: ["citation"]
+body:
+  - type: input
+    id: entry
+    attributes:
+      label: Entry
+      description: Path to the entry.
+    validations:
+      required: true
+  - type: input
+    id: url
+    attributes:
+      label: Citation URL
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is wrong
+      description: The source does not say what the entry claims it says, is a low-quality source, or is the wrong kind of source for this claim.
+    validations:
+      required: true
+  - type: input
+    id: better-source
+    attributes:
+      label: A better source, if you know one

--- a/.github/ISSUE_TEMPLATE/classification-dispute.yml
+++ b/.github/ISSUE_TEMPLATE/classification-dispute.yml
@@ -1,0 +1,25 @@
+name: Classification dispute
+description: An entry's family, maturity level, or category assignment looks wrong.
+title: "[classification]: "
+labels: ["classification"]
+body:
+  - type: input
+    id: entry
+    attributes:
+      label: Entry
+    validations:
+      required: true
+  - type: input
+    id: current
+    attributes:
+      label: Current classification
+      description: Current family and/or maturity value from the frontmatter.
+    validations:
+      required: true
+  - type: textarea
+    id: dispute
+    attributes:
+      label: What you think it should be, and why
+      description: Cite the reasoning, and a source if the family taxonomy itself needs to change.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a question / propose an entry not yet queued
+    url: https://github.com/mjmirza/patterns/discussions
+    about: For open-ended discussion before it becomes a scoped issue.

--- a/.github/ISSUE_TEMPLATE/duplicate-pattern.yml
+++ b/.github/ISSUE_TEMPLATE/duplicate-pattern.yml
@@ -1,0 +1,24 @@
+name: Duplicate or overlapping pattern
+description: Two entries cover substantially the same thing under different names.
+title: "[duplicate]: "
+labels: ["duplicate"]
+body:
+  - type: input
+    id: entry-a
+    attributes:
+      label: First entry
+    validations:
+      required: true
+  - type: input
+    id: entry-b
+    attributes:
+      label: Second entry
+    validations:
+      required: true
+  - type: textarea
+    id: overlap
+    attributes:
+      label: What overlaps
+      description: Where the two entries genuinely describe the same pattern, versus where a real, citable distinction exists that should be kept as two entries.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/factual-correction.yml
+++ b/.github/ISSUE_TEMPLATE/factual-correction.yml
@@ -1,0 +1,26 @@
+name: Factual correction
+description: A claim in a published entry is wrong, outdated, or overstated.
+title: "[correction]: "
+labels: ["correction"]
+body:
+  - type: input
+    id: entry
+    attributes:
+      label: Entry
+      description: Path to the entry, e.g. patterns/17-ai-agentic/react.md
+    validations:
+      required: true
+  - type: textarea
+    id: claim
+    attributes:
+      label: The claim as written
+      description: Quote the exact sentence or line that is wrong.
+    validations:
+      required: true
+  - type: textarea
+    id: correction
+    attributes:
+      label: What it should say instead, and why
+      description: State the correct claim and cite the source that supports it.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/new-pattern.yml
+++ b/.github/ISSUE_TEMPLATE/new-pattern.yml
@@ -1,0 +1,40 @@
+name: New pattern proposal
+description: Propose a pattern that is not yet in the catalogue or the authoring queue.
+title: "[new pattern]: "
+labels: ["new-pattern"]
+body:
+  - type: input
+    id: name
+    attributes:
+      label: Pattern name
+      description: The name you would give the entry, plus any common aliases.
+    validations:
+      required: true
+  - type: input
+    id: family
+    attributes:
+      label: Family
+      description: Which family under patterns/ does this belong to, or is it a new family?
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem it solves
+      description: One or two sentences on the situation that creates the need for this pattern.
+    validations:
+      required: true
+  - type: textarea
+    id: sources
+    attributes:
+      label: Primary sources
+      description: Where does this pattern come from? A book, a paper, a vendor engineering doc. Link it.
+    validations:
+      required: true
+  - type: checkboxes
+    id: not-duplicate
+    attributes:
+      label: Confirmation
+      options:
+        - label: I checked the published entries and docs/AUTHORING-QUEUE.json and this is not already covered.
+          required: true

--- a/.github/ISSUE_TEMPLATE/production-use-correction.yml
+++ b/.github/ISSUE_TEMPLATE/production-use-correction.yml
@@ -1,0 +1,24 @@
+name: Production-use claim correction
+description: An entry's "seen in production" or adoption claim is unsourced, outdated, or wrong.
+title: "[production-use]: "
+labels: ["production-use"]
+body:
+  - type: input
+    id: entry
+    attributes:
+      label: Entry
+    validations:
+      required: true
+  - type: textarea
+    id: claim
+    attributes:
+      label: The claim as written
+    validations:
+      required: true
+  - type: textarea
+    id: correction
+    attributes:
+      label: What is wrong with it, and what should replace it
+      description: A retraction (no source exists) or a corrected claim with a real, checkable source.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/security-concern.yml
+++ b/.github/ISSUE_TEMPLATE/security-concern.yml
@@ -1,0 +1,24 @@
+name: Security concern
+description: A non-sensitive security issue -- an insecure code sample, a risky script. For a sensitive report, use the Security tab's private advisory instead.
+title: "[security]: "
+labels: ["security"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        If this is a live exploit or could leak a credential, do not file it
+        here. Use this repository's Security tab, "Report a vulnerability."
+        This template is for non-sensitive issues, such as an insecure code
+        sample presented as best practice.
+  - type: input
+    id: location
+    attributes:
+      label: File or entry
+    validations:
+      required: true
+  - type: textarea
+    id: issue
+    attributes:
+      label: The issue
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+## What this changes
+
+<!-- One or two sentences. A new entry, a correction, a citation repair, tooling. -->
+
+## Verification
+
+<!-- Paste the real output of the four gates you ran locally. Not a claim that
+     they pass -- the actual command output. -->
+
+- [ ] `python3 tools/check-structure.py`
+- [ ] `python3 tools/check-prose.py`
+- [ ] `python3 tools/check-code.py --strict`
+- [ ] `python3 tools/validate-refs.py --strict`
+- [ ] `npx --yes markdownlint-cli2@0.23.2 ...`
+- [ ] If a published entry or the queue changed: `tools/gen-indexes.py` and
+      `tools/gen-catalogue-status.py` were re-run and the regenerated files
+      are committed in this PR.
+
+## For a new or corrected entry
+
+- [ ] All eighteen dimensions from `docs/ENTRY-TEMPLATE.md` are present.
+- [ ] Every factual claim traces to a citation that resolves.
+- [ ] No invented statistics, production-use claims, or vendor names.
+- [ ] Prose is original, not paraphrased from a single source without
+      attribution.
+
+## Notes for reviewers
+
+<!-- Anything a reviewer should specifically look at: a contested
+     classification, a claim you are not fully sure of, a source you could
+     not independently confirm. -->

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,32 @@
+<!-- freshness: frozen -->
+
+# Security policy
+
+This is a documentation catalogue: markdown pattern entries plus small,
+non-networked code samples used to prove a pattern compiles. There is no
+running service and no user data. Security reports here are almost always
+about one of two things.
+
+## What counts as a security concern
+
+- A code sample in a published entry that demonstrates or normalizes an
+  insecure practice (for example a hardcoded secret, a SQL string built by
+  concatenation, disabled TLS verification) presented as if it were the
+  recommended way to build the pattern.
+- A citation or automation script (`tools/*.py`, `.github/workflows/*.yml`)
+  that could be abused to run untrusted code or leak a token.
+
+## How to report
+
+Do not open a public issue for a live exploit or a token leak. Use GitHub's
+private vulnerability reporting for this repository (Security tab, "Report a
+vulnerability"), or use the `security-concern` issue template for anything
+that does not need to stay private (for example, an insecure code sample in
+an entry).
+
+## Response
+
+A maintainer acknowledges a private report within a reasonable time and, once
+confirmed, ships a fix as a normal pull request through the same branch, PR,
+CI-green, squash-merge workflow as any other change. Credit is given in the
+fixing commit unless the reporter asks to stay anonymous.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(ci)"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,26 @@
+cff-version: 1.2.0
+message: "If you use this catalogue, please cite it as below."
+title: "Patterns: A Master-Level Software Patterns Reference"
+abstract: >-
+  An open, community-correctable catalogue of software design and
+  architecture patterns. Every entry carries eighteen mandatory dimensions
+  (problem, forces, structure, dynamics, trade-offs, testing strategy,
+  production evidence, and more) and every factual claim cites a primary
+  source that is verified to resolve in continuous integration.
+type: dataset
+authors:
+  - family-names: Iqbal
+    given-names: Mirza
+repository-code: "https://github.com/mjmirza/patterns"
+url: "https://github.com/mjmirza/patterns"
+license: CC-BY-4.0
+version: "0.1.0"
+date-released: "2026-08-03"
+keywords:
+  - software-design-patterns
+  - software-architecture
+  - reference
+  - catalogue
+  - refactoring
+  - distributed-systems
+  - ai-agentic-patterns

--- a/README.md
+++ b/README.md
@@ -11,6 +11,23 @@ primary sources, carries eighteen mandatory dimensions, and cites every claim.
 ![Original prose](https://img.shields.io/badge/prose-100%25%20original-brightgreen)
 ![PRs Welcome](https://img.shields.io/badge/PRs-welcome-blueviolet)
 
+<!-- BADGES:AUTOGEN:START -->
+![CI](https://github.com/mjmirza/patterns/actions/workflows/ci.yml/badge.svg?branch=main)
+![Latest release](https://img.shields.io/github/v/release/mjmirza/patterns?display_name=tag)
+![Contributors](https://img.shields.io/github/contributors/mjmirza/patterns)
+![Open issues](https://img.shields.io/github/issues/mjmirza/patterns)
+![Schema version](https://img.shields.io/badge/schema-v1.0-informational)
+![Published entries](https://img.shields.io/badge/published-98-brightgreen)
+![Planned entries](https://img.shields.io/badge/planned-789-lightgrey)
+![Catalogue completion](https://img.shields.io/badge/completion-11.0%25-yellow)
+![References checked](https://img.shields.io/badge/references%20checked-785-brightgreen)
+![Stale entries](https://img.shields.io/badge/stale%20entries-0-brightgreen)
+![Code examples tested](https://img.shields.io/badge/code%20examples-compiled%20in%20CI-brightgreen)
+<!-- BADGES:AUTOGEN:END -->
+
+There is no documentation site yet (no rendered docs build to badge). Tracked
+as an open item in `docs/GOVERNANCE-AUDIT-2026-08-03.md`.
+
 ## What this is
 
 A reference you can hand to a staff engineer and have them find something they

--- a/dist/catalogue-status.json
+++ b/dist/catalogue-status.json
@@ -4,6 +4,8 @@
   "target_total": 887,
   "families_total": 29,
   "families_complete": 2,
+  "stale_entries": 0,
+  "references_checked": 785,
   "rows": [
     {
       "family": "01-gof",

--- a/docs/ENTRY-TEMPLATE.md
+++ b/docs/ENTRY-TEMPLATE.md
@@ -1,5 +1,9 @@
 # Entry Template. The Master Level Contract
 
+Schema version 1.0. This version number changes only when a dimension is
+added, removed, or its required shape changes, and `tools/check-structure.py`
+is updated to match in the same commit.
+
 Every pattern entry in this repository carries all 18 dimensions below. An entry
 missing a dimension is not finished. This is the single difference between a
 master reference and a getting started overview, and it is enforced by

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -8,6 +8,8 @@ Target (published plus planned): 887
 Completion: 11.0%
 Families: 29
 Families complete: 2
+Stale entries (untouched past 180 days): 0
+References checked (live in .ref-cache.json): 785
 
 | # | Family | Published | Planned | Target | Percent |
 |---|---|---|---|---|---|

--- a/tools/gen-catalogue-status.py
+++ b/tools/gen-catalogue-status.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 import csv
 import json
 import re
+import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -18,6 +20,9 @@ SCOPE_PATH = ROOT / "docs" / "SCOPE-TARGET.json"
 README_PATH = ROOT / "README.md"
 PROGRESS_PATH = ROOT / "docs" / "PROGRESS.md"
 DIST_DIR = ROOT / "dist"
+
+# An entry is stale past this many days since its last real edit (git log).
+STALE_DAYS = 180
 
 FRONTMATTER = re.compile(r"\A---\n(.*?)\n---\n", re.S)
 VALID_MATURITY = {"canonical", "established", "emerging", "contested", "deprecated"}
@@ -95,6 +100,31 @@ def published_by_family() -> dict[str, list[dict]]:
     return result
 
 
+def stale_count(published_paths: set[str]) -> int:
+    if not (ROOT / ".git").exists():
+        return 0
+    stale = 0
+    for rel in published_paths:
+        path = ROOT / rel
+        if not path.exists():
+            continue
+        try:
+            out = subprocess.run(
+                ["git", "log", "-1", "--format=%ct", "--", rel],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            ts = int(out.stdout.strip())
+        except (ValueError, subprocess.SubprocessError):
+            continue
+        age_days = (datetime.now(timezone.utc).timestamp() - ts) / 86400
+        if age_days > STALE_DAYS:
+            stale += 1
+    return stale
+
+
 def planned_by_family(published_paths: set[str]) -> dict[str, int]:
     # Planned = queue entry not yet on disk, matching next-batch.py's filter.
     if not QUEUE_PATH.exists():
@@ -109,7 +139,7 @@ def planned_by_family(published_paths: set[str]) -> dict[str, int]:
     return counts
 
 
-def build_rows() -> tuple[list[dict], int, int]:
+def build_rows() -> tuple[list[dict], int, int, int]:
     pub = published_by_family()
     published_paths = {
         f"patterns/{fam}/{e['slug']}.md"
@@ -117,6 +147,7 @@ def build_rows() -> tuple[list[dict], int, int]:
         for e in entries
     }
     planned = planned_by_family(published_paths)
+    stale = stale_count(published_paths)
     families = sorted(set(FAMILY_ORIGIN) | set(pub) | set(planned))
     rows = []
     total_pub = 0
@@ -144,10 +175,17 @@ def build_rows() -> tuple[list[dict], int, int]:
         )
         total_pub += n_pub
         total_target += target
-    return rows, total_pub, total_target
+    return rows, total_pub, total_target, stale
 
 
-def write_dist(rows: list[dict], total_pub: int, total_target: int) -> None:
+def references_checked() -> int:
+    cache_path = ROOT / ".ref-cache.json"
+    if not cache_path.exists():
+        return 0
+    return len(json.loads(cache_path.read_text()))
+
+
+def write_dist(rows: list[dict], total_pub: int, total_target: int, stale: int) -> None:
     DIST_DIR.mkdir(exist_ok=True)
     payload = {
         "generated_by": "tools/gen-catalogue-status.py",
@@ -157,6 +195,8 @@ def write_dist(rows: list[dict], total_pub: int, total_target: int) -> None:
         "families_complete": sum(
             1 for r in rows if r["published"] == r["target"] and r["target"] > 0
         ),
+        "stale_entries": stale,
+        "references_checked": references_checked(),
         "rows": rows,
     }
     (DIST_DIR / "catalogue-status.json").write_text(
@@ -178,7 +218,9 @@ def write_dist(rows: list[dict], total_pub: int, total_target: int) -> None:
             )
 
 
-def write_progress(rows: list[dict], total_pub: int, total_target: int) -> None:
+def write_progress(
+    rows: list[dict], total_pub: int, total_target: int, stale: int
+) -> None:
     complete = sum(1 for r in rows if r["published"] == r["target"] and r["target"] > 0)
     lines = [
         "# Catalogue Progress",
@@ -191,6 +233,8 @@ def write_progress(rows: list[dict], total_pub: int, total_target: int) -> None:
         f"Completion: {round(100 * total_pub / total_target, 1) if total_target else 0}%",
         f"Families: {len(rows)}",
         f"Families complete: {complete}",
+        f"Stale entries (untouched past {STALE_DAYS} days): {stale}",
+        f"References checked (live in .ref-cache.json): {references_checked()}",
         "",
         "| # | Family | Published | Planned | Target | Percent |",
         "|---|---|---|---|---|---|",
@@ -203,7 +247,9 @@ def write_progress(rows: list[dict], total_pub: int, total_target: int) -> None:
     PROGRESS_PATH.write_text("\n".join(lines) + "\n")
 
 
-def rewrite_readme(rows: list[dict], total_pub: int, total_target: int) -> None:
+def rewrite_readme(
+    rows: list[dict], total_pub: int, total_target: int, stale: int
+) -> None:
     text = README_PATH.read_text()
 
     text = re.sub(
@@ -215,6 +261,30 @@ def rewrite_readme(rows: list[dict], total_pub: int, total_target: int) -> None:
         r"!\[Entries\]\(https://img\.shields\.io/badge/entries-[^)]+\)",
         f"![Entries](https://img.shields.io/badge/entries-{total_pub}%20published%20%2F%20{total_target}%20planned-yellow)",
         text,
+    )
+
+    completion = round(100 * total_pub / total_target, 1) if total_target else 0.0
+    refs = references_checked()
+    dynamic_block = "\n".join(
+        [
+            "![CI](https://github.com/mjmirza/patterns/actions/workflows/ci.yml/badge.svg?branch=main)",
+            "![Latest release](https://img.shields.io/github/v/release/mjmirza/patterns?display_name=tag)",
+            "![Contributors](https://img.shields.io/github/contributors/mjmirza/patterns)",
+            "![Open issues](https://img.shields.io/github/issues/mjmirza/patterns)",
+            "![Schema version](https://img.shields.io/badge/schema-v1.0-informational)",
+            f"![Published entries](https://img.shields.io/badge/published-{total_pub}-brightgreen)",
+            f"![Planned entries](https://img.shields.io/badge/planned-{total_target - total_pub}-lightgrey)",
+            f"![Catalogue completion](https://img.shields.io/badge/completion-{completion}%25-yellow)",
+            f"![References checked](https://img.shields.io/badge/references%20checked-{refs}-brightgreen)",
+            f"![Stale entries](https://img.shields.io/badge/stale%20entries-{stale}-brightgreen)",
+            "![Code examples tested](https://img.shields.io/badge/code%20examples-compiled%20in%20CI-brightgreen)",
+        ]
+    )
+    text = re.sub(
+        r"<!-- BADGES:AUTOGEN:START -->.*?<!-- BADGES:AUTOGEN:END -->",
+        f"<!-- BADGES:AUTOGEN:START -->\n{dynamic_block}\n<!-- BADGES:AUTOGEN:END -->",
+        text,
+        flags=re.S,
     )
 
     table_lines = [
@@ -239,11 +309,13 @@ def rewrite_readme(rows: list[dict], total_pub: int, total_target: int) -> None:
 
 
 def main() -> int:
-    rows, total_pub, total_target = build_rows()
-    write_dist(rows, total_pub, total_target)
-    write_progress(rows, total_pub, total_target)
-    rewrite_readme(rows, total_pub, total_target)
-    print(f"published={total_pub} target={total_target} families={len(rows)}")
+    rows, total_pub, total_target, stale = build_rows()
+    write_dist(rows, total_pub, total_target, stale)
+    write_progress(rows, total_pub, total_target, stale)
+    rewrite_readme(rows, total_pub, total_target, stale)
+    print(
+        f"published={total_pub} target={total_target} families={len(rows)} stale={stale}"
+    )
     return 0
 
 


### PR DESCRIPTION
## Summary
- Adds .github/CODE_OF_CONDUCT.md, SECURITY.md, CONTRIBUTING.md, CODEOWNERS, PULL_REQUEST_TEMPLATE.md
- Adds 9 issue templates + config.yml under .github/ISSUE_TEMPLATE/
- Adds .github/dependabot.yml (github-actions ecosystem) and FUNDING.yml
- Adds CITATION.cff (CFF 1.2.0)
- Declares schema version 1.0 in docs/ENTRY-TEMPLATE.md
- Extends tools/gen-catalogue-status.py: real, computed stale-entry count (git-log based, 180-day window) and references-checked count (from .ref-cache.json), wires a new AUTOGEN badge block into README.md (CI status, latest release, contributors, open issues, schema version, published/planned entries, catalogue completion %, references checked, stale entries, code-examples-tested) -- all dynamic or generator-computed, no hand-typed numbers
- No "documentation build" badge added -- no doc site exists yet, stated in prose instead of faking a badge (tracked in docs/GOVERNANCE-AUDIT-2026-08-03.md)

## Verification
- python3 tools/check-structure.py: 98/98 pass
- python3 tools/check-prose.py: 110/110 pass
- python3 tools/gen-catalogue-status-test.py: 2/2 pass
- npx markdownlint-cli2 0.23.2: 0 issues across 112 files
- 9 YAML issue templates parsed with PyYAML: all valid
- tools/gen-catalogue-status.py run: published=98 target=887 families=29 stale=0

## Test plan
- CI must go green on all 4 jobs before merge (never merge red)