### PR TITLE
feat(governance): contributor collision prevention + branch protection

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,12 +7,30 @@ Every entry in this catalogue carries the eighteen dimensions defined in
 That bar applies equally to a maintainer's own pull request and to a first
 time contributor's. Nothing merges by exception.
 
+## Claim your entry before you write it
+
+`main` is protected. every change lands through a pull request, never a
+direct push, and the same four gates must pass before a merge is possible.
+
+Before starting work on a queued entry, open a **draft pull request** with
+just an empty target file (or the frontmatter stub) at the exact path from
+`docs/AUTHORING-QUEUE.json`. That draft PR IS the claim. A CI job (`claim
+check`) compares every open PR's added files against every other open PR and
+against what is already published on `main`, and fails the newer PR if two
+people are working on the same path. Push the real content to that same
+branch as you write it; the claim never expires because the PR itself is the
+claim.
+
+If you see a `claim check` failure naming your path, someone got there
+first. Rebase onto a different, unclaimed entry from the queue instead.
+
 ## Before you open a pull request
 
 1. Read `docs/ENTRY-TEMPLATE.md`. It is the schema, not a suggestion.
 2. Check `docs/AUTHORING-QUEUE.json` and the family README under
    `patterns/<family>/README.md` so a new entry does not duplicate one
-   already published or already queued.
+   already published or already queued. Also check `gh pr list` for a draft
+   PR already claiming the same path.
 3. Run the local gates before you push, the same four gates CI runs:
 
    ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,24 @@ jobs:
           node-version: "22"
       - name: markdownlint-cli2
         run: npx --yes markdownlint-cli2@0.23.2
+
+  claims:
+    name: claim check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Fetch main for comparison
+        run: git fetch origin main --depth=200
+      - name: No two contributors on the same entry
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }} # BESTPRACTICE_OK: numeric field via env, never inlined into run:
+          BASE_SHA: origin/main
+        run: python3 tools/check-claims.py

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ __pycache__/
 node_modules/
 .claude/
 .codex-logs/
+.env
+.env.*
+*.pem
+*.key
+id_rsa*

--- a/tools/check-claims.py
+++ b/tools/check-claims.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Blocks a PR that adds a patterns/*.md path another open PR already
+touches, or a path already published on main. Runs in CI on pull_request."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def added_paths() -> list[str]:
+    base = os.environ.get("BASE_SHA", "origin/main")
+    out = subprocess.run(
+        ["git", "diff", "--name-status", f"{base}...HEAD"],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+        check=False,
+    ).stdout
+    added = []
+    for line in out.splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2 and parts[0] == "A":
+            path = parts[-1]
+            if path.startswith("patterns/") and path.endswith(".md"):
+                added.append(path)
+    return added
+
+
+def published_on_main(path: str) -> bool:
+    base = os.environ.get("BASE_SHA", "origin/main")
+    r = subprocess.run(
+        ["git", "cat-file", "-e", f"{base}:{path}"],
+        cwd=ROOT,
+        capture_output=True,
+        check=False,
+    )
+    return r.returncode == 0
+
+
+def sibling_pr_paths(this_pr: str) -> dict[str, int]:
+    prs = json.loads(
+        subprocess.run(
+            ["gh", "pr", "list", "--state", "open", "--json", "number"],
+            capture_output=True,
+            text=True,
+            cwd=ROOT,
+            check=False,
+        ).stdout
+        or "[]"
+    )
+    claims: dict[str, int] = {}
+    for pr in prs:
+        num = pr.get("number")
+        if num is None or str(num) == str(this_pr):
+            continue
+        files = json.loads(
+            subprocess.run(
+                ["gh", "pr", "view", str(num), "--json", "files"],
+                capture_output=True,
+                text=True,
+                cwd=ROOT,
+                check=False,
+            ).stdout
+            or '{"files": []}'
+        )
+        for f in files.get("files", []):
+            p = f.get("path", "")
+            if p.startswith("patterns/") and p.endswith(".md"):
+                claims[p] = num
+    return claims
+
+
+def main() -> int:
+    this_pr = os.environ.get("PR_NUMBER", "")
+    added = added_paths()
+    if not added:
+        print("no new patterns/*.md files added, nothing to check")
+        return 0
+
+    problems = []
+    for path in added:
+        if published_on_main(path):
+            problems.append(f"{path}: already published on main")
+
+    siblings = sibling_pr_paths(this_pr)
+    for path in added:
+        if path in siblings:
+            problems.append(f"{path}: already claimed by open PR #{siblings[path]}")
+
+    if problems:
+        print("CLAIM CHECK FAILED. Two contributors are working on the same entry.")
+        for p in problems:
+            print(f"  {p}")
+        print("")
+        print("Rebase off the entry that already exists, or pick a different")
+        print("entry from docs/AUTHORING-QUEUE.json. See .github/CONTRIBUTING.md.")
+        return 1
+
+    print(f"claim check clean: {len(added)} new entr(y/ies), no collisions")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/next-batch.py
+++ b/tools/next-batch.py
@@ -33,6 +33,46 @@ def passing() -> set[str]:
     }
 
 
+def claimed_paths() -> dict[str, int]:
+    # A path with an open PR is claimed. Fail open on any gh/network error.
+    try:
+        prs = json.loads(
+            subprocess.run(
+                ["gh", "pr", "list", "--state", "open", "--json", "number"],
+                capture_output=True,
+                text=True,
+                cwd=ROOT,
+                timeout=20,
+            ).stdout
+            or "[]"
+        )
+    except Exception:
+        return {}
+    claims: dict[str, int] = {}
+    for pr in prs:
+        num = pr.get("number")
+        if num is None:
+            continue
+        try:
+            files = json.loads(
+                subprocess.run(
+                    ["gh", "pr", "view", str(num), "--json", "files"],
+                    capture_output=True,
+                    text=True,
+                    cwd=ROOT,
+                    timeout=20,
+                ).stdout
+                or '{"files": []}'
+            )
+        except Exception:
+            continue
+        for f in files.get("files", []):
+            path = f.get("path", "")
+            if path.startswith("patterns/") and path.endswith(".md"):
+                claims[path] = num
+    return claims
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--size", type=int, default=8)
@@ -46,9 +86,16 @@ def main() -> int:
 
     entries = json.loads(QUEUE.read_text())
     done = passing()
-    todo = [e for e in entries if e["path"] not in done]
+    claims = claimed_paths()
+    todo = [e for e in entries if e["path"] not in done and e["path"] not in claims]
     if args.family:
         todo = [e for e in todo if e["path"].startswith(f"patterns/{args.family}")]
+
+    if claims and not args.status:
+        skipped = ", ".join(f"{p} (PR #{n})" for p, n in list(claims.items())[:5])
+        print(
+            f"skipping {len(claims)} claimed by an open PR: {skipped}", file=sys.stderr
+        )
 
     if args.status:
         by_family: dict[str, list[int]] = {}


### PR DESCRIPTION
## Summary

Addresses two real gaps found while the repo was still private:

**1. Contributor collision prevention** (a human contributor and this repo's own automation could otherwise write the same pattern entry at the same time):
- New CI job `claim check` (tools/check-claims.py): fails a PR if it adds a `patterns/*.md` path that another OPEN PR already touches, or that already exists on `main`. The claim mechanism is the draft PR itself, no new registry file needed.
- `tools/next-batch.py` now queries open PRs live via `gh pr list`/`gh pr view` and skips any queue entry already claimed by an open PR, so this repo's own automated authoring rounds never pick an entry a human contributor has already started.
- `.github/CONTRIBUTING.md` documents the claim-via-draft-PR protocol.

**2. Branch protection on `main`** (there was none):
- PR required (even for admins), all 4 CI status checks required, no force-push, no branch deletion, linear history required, strict (must be up to date before merge).

**3. Public-repo security/privacy audit** (run after the repo was flipped public):
- Full-history `gitleaks detect`: 0 leaks across all 35 commits.
- Grepped full history for hardcoded local paths, personal emails, employer names: found one local absolute path in the original foundation commit's code sample (already absent from current HEAD, not a secret, matches the already-public git author identity -- noted, not rewriting history for it).
- Verified `docs/council/` (the excluded-from-markdownlint gap-analysis doc) contains no sensitive content, appropriate to be public.
- No `.env`/credential/key files ever committed in history.
- No `secrets.*` referenced in any workflow.
- Hardened `.gitignore` with explicit `.env`/`.pem`/`.key`/`id_rsa*` patterns as defense in depth (none were ever tracked).

## Verification
- check-claims.py: tested positive (two PRs on same path -> blocks, exit 1) and negative (self-exclusion, own PR's own file -> clean, exit 0) in an isolated throwaway clone.
- next-batch.py: py_compile clean, fail-open confirmed on gh error.
- check-structure.py: 113/113 pass. check-prose.py: 125/125 pass. markdownlint-cli2: 0 issues across 124 files. YAML valid.

## Test plan
- CI must go green on all 4 jobs before merge (never merge red)