### PR TITLE
chore(11-ddd): rename family folder to 11-domain-driven-design

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ README does not claim they are implemented.
 | 08 | [Cloud and Distributed](patterns/08-cloud-distributed/) | Azure Architecture Center | 42 | 0 | 42 |
 | 09 | [Concurrency and Parallelism](patterns/09-concurrency/) | Schmidt POSA 2 | 0 | 40 | 40 |
 | 10 | [Microservices](patterns/10-microservices/) | Richardson | 44 | 5 | 49 |
-| 11 | [Domain-Driven Design](patterns/11-ddd/) | Evans, Vernon | 29 | 6 | 35 |
+| 11 | [Domain-Driven Design](patterns/11-domain-driven-design/) | Evans, Vernon | 29 | 6 | 35 |
 | 12 | [Data and Storage](patterns/12-data-storage/) | Kleppmann | 0 | 41 | 41 |
 | 13 | [Frontend and UI](patterns/13-frontend-ui/) | Framework documentation | 0 | 34 | 34 |
 | 14 | [Testing](patterns/14-testing/) | Meszaros, xUnit Test Patterns | 30 | 0 | 30 |

--- a/dist/catalogue-status.csv
+++ b/dist/catalogue-status.csv
@@ -9,7 +9,7 @@ family,name,published,planned,target,percent
 08-cloud-distributed,Cloud and Distributed,42,0,42,100.0
 09-concurrency,Concurrency and Parallelism,0,40,40,0.0
 10-microservices,Microservices,44,5,49,89.8
-11-ddd,Domain-Driven Design,29,6,35,82.9
+11-domain-driven-design,Domain-Driven Design,29,6,35,82.9
 12-data-storage,Data and Storage,0,41,41,0.0
 13-frontend-ui,Frontend and UI,0,34,34,0.0
 14-testing,Testing,30,0,30,100.0

--- a/dist/catalogue-status.json
+++ b/dist/catalogue-status.json
@@ -131,7 +131,7 @@
       }
     },
     {
-      "family": "11-ddd",
+      "family": "11-domain-driven-design",
       "name": "Domain-Driven Design",
       "origin": "Evans, Vernon",
       "published": 29,

--- a/docs/AUTHORING-QUEUE.json
+++ b/docs/AUTHORING-QUEUE.json
@@ -990,203 +990,203 @@
     "name": "Ubiquitous Language",
     "slug": "ubiquitous-language",
     "category": "ddd",
-    "path": "patterns/11-ddd/ubiquitous-language.md",
+    "path": "patterns/11-domain-driven-design/ubiquitous-language.md",
     "focus": ""
   },
   {
     "name": "Bounded Context",
     "slug": "bounded-context",
     "category": "ddd",
-    "path": "patterns/11-ddd/bounded-context.md",
+    "path": "patterns/11-domain-driven-design/bounded-context.md",
     "focus": ""
   },
   {
     "name": "Context Map",
     "slug": "context-map",
     "category": "ddd",
-    "path": "patterns/11-ddd/context-map.md",
+    "path": "patterns/11-domain-driven-design/context-map.md",
     "focus": ""
   },
   {
     "name": "Core Domain",
     "slug": "core-domain",
     "category": "ddd",
-    "path": "patterns/11-ddd/core-domain.md",
+    "path": "patterns/11-domain-driven-design/core-domain.md",
     "focus": ""
   },
   {
     "name": "Generic Subdomain",
     "slug": "generic-subdomain",
     "category": "ddd",
-    "path": "patterns/11-ddd/generic-subdomain.md",
+    "path": "patterns/11-domain-driven-design/generic-subdomain.md",
     "focus": ""
   },
   {
     "name": "Supporting Subdomain",
     "slug": "supporting-subdomain",
     "category": "ddd",
-    "path": "patterns/11-ddd/supporting-subdomain.md",
+    "path": "patterns/11-domain-driven-design/supporting-subdomain.md",
     "focus": ""
   },
   {
     "name": "Shared Kernel",
     "slug": "shared-kernel",
     "category": "ddd",
-    "path": "patterns/11-ddd/shared-kernel.md",
+    "path": "patterns/11-domain-driven-design/shared-kernel.md",
     "focus": ""
   },
   {
     "name": "Customer Supplier",
     "slug": "customer-supplier",
     "category": "ddd",
-    "path": "patterns/11-ddd/customer-supplier.md",
+    "path": "patterns/11-domain-driven-design/customer-supplier.md",
     "focus": ""
   },
   {
     "name": "Conformist",
     "slug": "conformist",
     "category": "ddd",
-    "path": "patterns/11-ddd/conformist.md",
+    "path": "patterns/11-domain-driven-design/conformist.md",
     "focus": ""
   },
   {
     "name": "Anticorruption Layer",
     "slug": "anticorruption-layer",
     "category": "ddd",
-    "path": "patterns/11-ddd/anticorruption-layer.md",
+    "path": "patterns/11-domain-driven-design/anticorruption-layer.md",
     "focus": ""
   },
   {
     "name": "Open Host Service",
     "slug": "open-host-service",
     "category": "ddd",
-    "path": "patterns/11-ddd/open-host-service.md",
+    "path": "patterns/11-domain-driven-design/open-host-service.md",
     "focus": ""
   },
   {
     "name": "Published Language",
     "slug": "published-language",
     "category": "ddd",
-    "path": "patterns/11-ddd/published-language.md",
+    "path": "patterns/11-domain-driven-design/published-language.md",
     "focus": ""
   },
   {
     "name": "Separate Ways",
     "slug": "separate-ways",
     "category": "ddd",
-    "path": "patterns/11-ddd/separate-ways.md",
+    "path": "patterns/11-domain-driven-design/separate-ways.md",
     "focus": ""
   },
   {
     "name": "Big Ball of Mud",
     "slug": "big-ball-of-mud",
     "category": "ddd",
-    "path": "patterns/11-ddd/big-ball-of-mud.md",
+    "path": "patterns/11-domain-driven-design/big-ball-of-mud.md",
     "focus": ""
   },
   {
     "name": "Entity",
     "slug": "entity",
     "category": "ddd",
-    "path": "patterns/11-ddd/entity.md",
+    "path": "patterns/11-domain-driven-design/entity.md",
     "focus": ""
   },
   {
     "name": "Value Object",
     "slug": "value-object",
     "category": "ddd",
-    "path": "patterns/11-ddd/value-object.md",
+    "path": "patterns/11-domain-driven-design/value-object.md",
     "focus": ""
   },
   {
     "name": "Aggregate Root",
     "slug": "aggregate-root",
     "category": "ddd",
-    "path": "patterns/11-ddd/aggregate-root.md",
+    "path": "patterns/11-domain-driven-design/aggregate-root.md",
     "focus": ""
   },
   {
     "name": "Domain Event",
     "slug": "domain-event",
     "category": "ddd",
-    "path": "patterns/11-ddd/domain-event.md",
+    "path": "patterns/11-domain-driven-design/domain-event.md",
     "focus": ""
   },
   {
     "name": "Repository",
     "slug": "repository",
     "category": "ddd",
-    "path": "patterns/11-ddd/repository.md",
+    "path": "patterns/11-domain-driven-design/repository.md",
     "focus": ""
   },
   {
     "name": "Factory",
     "slug": "factory",
     "category": "ddd",
-    "path": "patterns/11-ddd/factory.md",
+    "path": "patterns/11-domain-driven-design/factory.md",
     "focus": ""
   },
   {
     "name": "Domain Service",
     "slug": "domain-service",
     "category": "ddd",
-    "path": "patterns/11-ddd/domain-service.md",
+    "path": "patterns/11-domain-driven-design/domain-service.md",
     "focus": ""
   },
   {
     "name": "Application Service",
     "slug": "application-service",
     "category": "ddd",
-    "path": "patterns/11-ddd/application-service.md",
+    "path": "patterns/11-domain-driven-design/application-service.md",
     "focus": ""
   },
   {
     "name": "Module",
     "slug": "module",
     "category": "ddd",
-    "path": "patterns/11-ddd/module.md",
+    "path": "patterns/11-domain-driven-design/module.md",
     "focus": ""
   },
   {
     "name": "Specification",
     "slug": "specification",
     "category": "ddd",
-    "path": "patterns/11-ddd/specification.md",
+    "path": "patterns/11-domain-driven-design/specification.md",
     "focus": ""
   },
   {
     "name": "Layered Architecture",
     "slug": "layered-architecture",
     "category": "ddd",
-    "path": "patterns/11-ddd/layered-architecture.md",
+    "path": "patterns/11-domain-driven-design/layered-architecture.md",
     "focus": ""
   },
   {
     "name": "Process Manager",
     "slug": "process-manager",
     "category": "ddd",
-    "path": "patterns/11-ddd/process-manager.md",
+    "path": "patterns/11-domain-driven-design/process-manager.md",
     "focus": ""
   },
   {
     "name": "Domain Primitive",
     "slug": "domain-primitive",
     "category": "ddd",
-    "path": "patterns/11-ddd/domain-primitive.md",
+    "path": "patterns/11-domain-driven-design/domain-primitive.md",
     "focus": ""
   },
   {
     "name": "Event Storming",
     "slug": "event-storming",
     "category": "ddd",
-    "path": "patterns/11-ddd/event-storming.md",
+    "path": "patterns/11-domain-driven-design/event-storming.md",
     "focus": ""
   },
   {
     "name": "Domain Storytelling",
     "slug": "domain-storytelling",
     "category": "ddd",
-    "path": "patterns/11-ddd/domain-storytelling.md",
+    "path": "patterns/11-domain-driven-design/domain-storytelling.md",
     "focus": ""
   },
   {
@@ -3412,42 +3412,42 @@
     "name": "Open Host Service and Published Language",
     "slug": "open-host-service-and-published-language",
     "category": "domain-driven design",
-    "path": "patterns/11-ddd/open-host-service-and-published-language.md",
+    "path": "patterns/11-domain-driven-design/open-host-service-and-published-language.md",
     "focus": ""
   },
   {
     "name": "Aggregate",
     "slug": "aggregate",
     "category": "domain-driven design",
-    "path": "patterns/11-ddd/aggregate.md",
+    "path": "patterns/11-domain-driven-design/aggregate.md",
     "focus": ""
   },
   {
     "name": "Subdomain Discovery",
     "slug": "subdomain-discovery",
     "category": "domain-driven design",
-    "path": "patterns/11-ddd/subdomain-discovery.md",
+    "path": "patterns/11-domain-driven-design/subdomain-discovery.md",
     "focus": ""
   },
   {
     "name": "Context Canvas",
     "slug": "context-canvas",
     "category": "domain-driven design",
-    "path": "patterns/11-ddd/context-canvas.md",
+    "path": "patterns/11-domain-driven-design/context-canvas.md",
     "focus": ""
   },
   {
     "name": "Partnership",
     "slug": "partnership",
     "category": "domain-driven design",
-    "path": "patterns/11-ddd/partnership.md",
+    "path": "patterns/11-domain-driven-design/partnership.md",
     "focus": ""
   },
   {
     "name": "Saga versus Process Manager",
     "slug": "saga-versus-process-manager",
     "category": "domain-driven design",
-    "path": "patterns/11-ddd/saga-versus-process-manager.md",
+    "path": "patterns/11-domain-driven-design/saga-versus-process-manager.md",
     "focus": ""
   },
   {

--- a/patterns/11-domain-driven-design/README.md
+++ b/patterns/11-domain-driven-design/README.md
@@ -47,7 +47,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
-| [Anticorruption Layer](anticorruption-layer.md) | canonical | 7,220 | A team owns a domain model they have deliberately shaped to match the Ubiquitous Language of their Bounded Context, see patterns/11-ddd/ubiquitous-language.md and ... |
+| [Anticorruption Layer](anticorruption-layer.md) | canonical | 7,220 | A team owns a domain model they have deliberately shaped to match the Ubiquitous Language of their Bounded Context, see patterns/11-domain-driven-design/ubiquitous-language.md and ... |
 
 ## Strategic
 

--- a/patterns/11-domain-driven-design/aggregate-root.md
+++ b/patterns/11-domain-driven-design/aggregate-root.md
@@ -1,7 +1,7 @@
 ---
 name: Aggregate Root
 slug: aggregate-root
-family: 11-ddd
+family: 11-domain-driven-design
 category: Domain-Driven Design
 aliases: [Root Entity, Aggregate Boundary, Consistency Boundary]
 first_described: "Evans 2003"

--- a/patterns/11-domain-driven-design/anticorruption-layer.md
+++ b/patterns/11-domain-driven-design/anticorruption-layer.md
@@ -1,7 +1,7 @@
 ---
 name: Anticorruption Layer
 slug: anticorruption-layer
-family: 11-ddd
+family: 11-domain-driven-design
 category: Integration
 aliases: [ACL, Anti-Corruption Layer, Translation Layer]
 first_described: "Eric Evans 2003"
@@ -54,8 +54,8 @@ it reads as a design.
 
 A team owns a domain model they have deliberately shaped to match the
 Ubiquitous Language of their Bounded Context, see
-`patterns/11-ddd/ubiquitous-language.md` and
-`patterns/11-ddd/bounded-context.md`. That model must exchange data with
+`patterns/11-domain-driven-design/ubiquitous-language.md` and
+`patterns/11-domain-driven-design/bounded-context.md`. That model must exchange data with
 another system whose model was shaped by a different team, a different era, or
 a different vendor, and was never designed to agree with the local one.
 
@@ -77,10 +77,10 @@ The situation shows up in three recurring shapes.
   inside the same company, built by different teams, each with a coherent
   internal model, need to exchange information, and neither model was
   designed with the other in mind. This is the case the Customer-Supplier and
-  Conformist relationships in `patterns/11-ddd/context-map.md` also address,
+  Conformist relationships in `patterns/11-domain-driven-design/context-map.md` also address,
   and Anticorruption Layer is the choice when the downstream team has neither
   the standing nor the willingness to adopt the upstream team's model
-  wholesale, see `patterns/11-ddd/conformist.md`.
+  wholesale, see `patterns/11-domain-driven-design/conformist.md`.
 
 In all three shapes the naive move is to let the foreign model's types, field
 names, and invariants flow straight through the boundary and into the domain
@@ -122,7 +122,7 @@ the forces genuinely favour it, see dimension 4.
 - **Organisational trust and negotiating power.** This force is not covered
   well by most catalog descriptions, but it decides whether Anticorruption
   Layer, Conformist, or Customer-Supplier is the right relationship on a
-  Context Map, see `patterns/11-ddd/context-map.md`. When the downstream team
+  Context Map, see `patterns/11-domain-driven-design/context-map.md`. When the downstream team
   cannot influence the upstream model, either because it is a vendor, a legacy
   system with no active owner, or an upstream team that will not
   collaborate, an ACL is close to mandatory. When the two teams can negotiate
@@ -146,7 +146,7 @@ Reach for an Anticorruption Layer when the following hold together.
   model. This includes vendor APIs, legacy systems slated for eventual
   replacement, and upstream teams unwilling to accommodate the downstream
   team's needs, the Conformist and Customer-Supplier relationships in
-  `patterns/11-ddd/context-map.md` cover the alternative postures when this
+  `patterns/11-domain-driven-design/context-map.md` cover the alternative postures when this
   condition does not hold.
 - The integration is expected to persist long enough, or matter enough, to
   justify writing and maintaining a translation layer instead of accepting the
@@ -160,7 +160,7 @@ Do NOT reach for an Anticorruption Layer in these situations.
 - **The two models genuinely agree, or agreement is achievable at low cost.**
   If a shared model across two Bounded Contexts is not only possible but
   actually cheaper to maintain than two models plus a translator, Shared
-  Kernel is the correct relationship, see `patterns/11-ddd/shared-kernel.md`.
+  Kernel is the correct relationship, see `patterns/11-domain-driven-design/shared-kernel.md`.
   Building an ACL to translate between two models that could simply be one
   model is pure overhead with no protective benefit, and it is incompatible
   with a Shared Kernel relationship for exactly this reason, the two patterns
@@ -171,7 +171,7 @@ Do NOT reach for an Anticorruption Layer in these situations.
   nothing from a translation layer, because there is no local conceptual
   integrity at risk. Adopting the upstream model directly, the Conformist
   relationship, is cheaper and honestly reflects the situation, see
-  `patterns/11-ddd/conformist.md`.
+  `patterns/11-domain-driven-design/conformist.md`.
 - **The integration is short-lived by design.** A one-off data migration
   script that runs once and is deleted does not need the ongoing maintenance
   investment an ACL represents. A single Adapter or a throwaway mapping
@@ -495,28 +495,28 @@ from.
 | Approach | Model purity | Coupling to foreign changes | Upfront cost | Ongoing maintenance | When it wins |
 |---|---|---|---|---|---|
 | Anticorruption Layer | High, domain never sees foreign types | Low, absorbed at one boundary | High, Facade, Adapter, Translator, tests | Ongoing, must track foreign side | Foreign model genuinely conflicts and the team has no influence over it |
-| Conformist (`patterns/11-ddd/conformist.md`) | None, domain adopts upstream model wholesale | High, every upstream change is a downstream change | Low, no translation to build | Low day to day, high if upstream changes often | Upstream will not collaborate and translation is not worth its cost |
-| Customer-Supplier (`patterns/11-ddd/context-map.md`) | High, downstream negotiates its own model | Managed, upstream accounts for downstream needs | Moderate, requires ongoing coordination | Moderate, relationship must be actively maintained | Both teams are in the same organisation and can negotiate priorities |
-| Shared Kernel (`patterns/11-ddd/shared-kernel.md`) | Deliberately merged, not separate | Very high by design, shared code is shared risk | Low to start, one model instead of two | High coordination cost as both sides change it together | The two contexts genuinely should evolve as one model, closely-collaborating teams |
+| Conformist (`patterns/11-domain-driven-design/conformist.md`) | None, domain adopts upstream model wholesale | High, every upstream change is a downstream change | Low, no translation to build | Low day to day, high if upstream changes often | Upstream will not collaborate and translation is not worth its cost |
+| Customer-Supplier (`patterns/11-domain-driven-design/context-map.md`) | High, downstream negotiates its own model | Managed, upstream accounts for downstream needs | Moderate, requires ongoing coordination | Moderate, relationship must be actively maintained | Both teams are in the same organisation and can negotiate priorities |
+| Shared Kernel (`patterns/11-domain-driven-design/shared-kernel.md`) | Deliberately merged, not separate | Very high by design, shared code is shared risk | Low to start, one model instead of two | High coordination cost as both sides change it together | The two contexts genuinely should evolve as one model, closely-collaborating teams |
 | Plain Adapter (`patterns/01-gof/adapter.md`) alone | Low, converts interface shape but not deeper model conflicts | Partial, absorbs interface mismatch, not conceptual mismatch | Low, a single class | Low | The mismatch is purely structural, method signatures differ but concepts agree |
 
 ## 13. Related and incompatible patterns
 
-- **Bounded Context, `patterns/11-ddd/bounded-context.md`.** The Anticorruption
+- **Bounded Context, `patterns/11-domain-driven-design/bounded-context.md`.** The Anticorruption
   Layer only makes sense at the seam between two Bounded Contexts, or between
   a Bounded Context and a system outside the organisation's modelling
   authority entirely. Without a defined, protected context on the inside,
   there is nothing for the layer to protect.
-- **Context Map, `patterns/11-ddd/context-map.md`.** The Context Map is where
+- **Context Map, `patterns/11-domain-driven-design/context-map.md`.** The Context Map is where
   a team decides, per relationship, whether Anticorruption Layer, Conformist,
   Customer-Supplier, or Shared Kernel governs a given seam. The ACL is one
   entry in that map, not a universal default.
-- **Conformist, `patterns/11-ddd/conformist.md`.** The direct alternative when
+- **Conformist, `patterns/11-domain-driven-design/conformist.md`.** The direct alternative when
   the downstream team decides translation is not worth its cost and instead
   adopts the upstream model as-is. Choosing between the two is a judgement
   about the cost of translation versus the cost of foreign concepts leaking
   in, discussed in dimension 3 and dimension 4.
-- **Customer-Supplier, `patterns/11-ddd/customer-supplier.md`.** A softer
+- **Customer-Supplier, `patterns/11-domain-driven-design/customer-supplier.md`.** A softer
   relationship for when the two teams can negotiate, sometimes used alongside
   a lighter ACL that mainly handles versioning rather than deep semantic
   conflict.
@@ -532,7 +532,7 @@ from.
   seam, protecting newly extracted services from the legacy system that has
   not yet been fully replaced, and is removed once the migration completes,
   as seen in both the Michelin case and the AWS sample repository.
-- **Shared Kernel, `patterns/11-ddd/shared-kernel.md`, incompatible.** These
+- **Shared Kernel, `patterns/11-domain-driven-design/shared-kernel.md`, incompatible.** These
   two patterns express opposite decisions about the same question, should the
   two models converge into one, or should they be kept deliberately separate
   with translation at the boundary. A codebase cannot honestly claim both for

--- a/patterns/11-domain-driven-design/application-service.md
+++ b/patterns/11-domain-driven-design/application-service.md
@@ -1,7 +1,7 @@
 ---
 name: Application Service
 slug: application-service
-family: 11-ddd
+family: 11-domain-driven-design
 category: Domain-Driven Design
 aliases: [Service Layer, Use Case Interactor, Application Layer Service]
 first_described: "Evans 2003"

--- a/patterns/11-domain-driven-design/big-ball-of-mud.md
+++ b/patterns/11-domain-driven-design/big-ball-of-mud.md
@@ -1,7 +1,7 @@
 ---
 name: Big Ball of Mud
 slug: big-ball-of-mud
-family: 11-ddd
+family: 11-domain-driven-design
 category: Anti-pattern
 aliases: [Spaghetti Architecture, Mud Ball]
 first_described: "Foote, Yoder 1997"

--- a/patterns/11-domain-driven-design/bounded-context.md
+++ b/patterns/11-domain-driven-design/bounded-context.md
@@ -1,7 +1,7 @@
 ---
 name: Bounded Context
 slug: bounded-context
-family: 11-ddd
+family: 11-domain-driven-design
 category: Strategic Design
 aliases: [Context Boundary, Model Boundary]
 first_described: "Evans 2003"

--- a/patterns/11-domain-driven-design/conformist.md
+++ b/patterns/11-domain-driven-design/conformist.md
@@ -1,7 +1,7 @@
 ---
 name: Conformist
 slug: conformist
-family: 11-ddd
+family: 11-domain-driven-design
 category: Strategic Design
 aliases: [CF, Conformist Relationship]
 first_described: "Evans 2003"
@@ -532,7 +532,7 @@ against real alternatives rather than a strawman.
 - **Core Domain.** A Conformist relationship rarely belongs anywhere near a
   Core Domain, because letting a vendor's vocabulary define the part of the
   system that differentiates the business trades away the one thing a Core
-  Domain exists to protect. See `patterns/11-ddd/core-domain.md` in this
+  Domain exists to protect. See `patterns/11-domain-driven-design/core-domain.md` in this
   repository for the fuller argument.
 
 ## 14. Refactoring path in and out
@@ -691,8 +691,8 @@ dimensions 3 and 10, not a separate concern.
     verified 2026-08-02, cited for the Anticorruption Layer comparison in
     dimensions 12 and 13, and for its own attribution of the pattern to
     Eric Evans.
-12. `patterns/11-ddd/context-map.md`, `patterns/11-ddd/bounded-context.md`,
-    and `patterns/11-ddd/core-domain.md`, this repository, for the internal
+12. `patterns/11-domain-driven-design/context-map.md`, `patterns/11-domain-driven-design/bounded-context.md`,
+    and `patterns/11-domain-driven-design/core-domain.md`, this repository, for the internal
     cross-references in dimensions 13 and 4.
 
 ## Code examples

--- a/patterns/11-domain-driven-design/context-map.md
+++ b/patterns/11-domain-driven-design/context-map.md
@@ -1,7 +1,7 @@
 ---
 name: Context Map
 slug: context-map
-family: 11-ddd
+family: 11-domain-driven-design
 category: Strategic Design
 aliases: [Bounded Context Map, Context Mapping]
 first_described: "Evans 2003"

--- a/patterns/11-domain-driven-design/core-domain.md
+++ b/patterns/11-domain-driven-design/core-domain.md
@@ -1,7 +1,7 @@
 ---
 name: Core Domain
 slug: core-domain
-family: 11-ddd
+family: 11-domain-driven-design
 category: Strategic Design
 aliases: [Core Domain Distillation, Domain Classification, Subdomain Triage]
 first_described: "Eric Evans 2003"

--- a/patterns/11-domain-driven-design/customer-supplier.md
+++ b/patterns/11-domain-driven-design/customer-supplier.md
@@ -1,7 +1,7 @@
 ---
 name: Customer-Supplier
 slug: customer-supplier
-family: 11-ddd
+family: 11-domain-driven-design
 category: Strategic Design
 aliases: [Customer/Supplier Development Teams, Customer-Supplier Development Team Relationship, Customer-Supplier Context Relationship]
 first_described: "Evans 2003"

--- a/patterns/11-domain-driven-design/domain-event.md
+++ b/patterns/11-domain-driven-design/domain-event.md
@@ -1,7 +1,7 @@
 ---
 name: Domain Event
 slug: domain-event
-family: 11-ddd
+family: 11-domain-driven-design
 category: Tactical
 aliases: [Business Event, Domain Notification]
 first_described: "Evans 2003, formalized by Fowler 2005 and Vernon 2013"

--- a/patterns/11-domain-driven-design/domain-primitive.md
+++ b/patterns/11-domain-driven-design/domain-primitive.md
@@ -1,7 +1,7 @@
 ---
 name: Domain Primitive
 slug: domain-primitive
-family: 11-ddd
+family: 11-domain-driven-design
 category: Tactical Modeling
 aliases: [Tiny Type, Wrapper Type, Strong Type, Notification-Aware Value Object]
 first_described: "Fowler and Yegor Bugayenko, popularized by Dan Bergh Johnsson and Daniel Deogun 2019"

--- a/patterns/11-domain-driven-design/domain-service.md
+++ b/patterns/11-domain-driven-design/domain-service.md
@@ -1,7 +1,7 @@
 ---
 name: Domain Service
 slug: domain-service
-family: 11-ddd
+family: 11-domain-driven-design
 category: Domain-Driven Design
 aliases: [Service Object, Stateless Domain Operation]
 first_described: "Evans 2003"

--- a/patterns/11-domain-driven-design/domain-storytelling.md
+++ b/patterns/11-domain-driven-design/domain-storytelling.md
@@ -1,7 +1,7 @@
 ---
 name: Domain Storytelling
 slug: domain-storytelling
-family: 11-ddd
+family: 11-domain-driven-design
 category: Strategic
 aliases: [Domain Story Modeling, Pictographic Domain Modeling]
 first_described: "Hofer and Schwentner 2021"

--- a/patterns/11-domain-driven-design/entity.md
+++ b/patterns/11-domain-driven-design/entity.md
@@ -1,7 +1,7 @@
 ---
 name: Entity
 slug: entity
-family: 11-ddd
+family: 11-domain-driven-design
 category: Tactical Modeling
 aliases: [Domain Entity, Identity Object, Reference Object]
 first_described: "Evans 2003"

--- a/patterns/11-domain-driven-design/event-storming.md
+++ b/patterns/11-domain-driven-design/event-storming.md
@@ -1,7 +1,7 @@
 ---
 name: Event Storming
 slug: event-storming
-family: 11-ddd
+family: 11-domain-driven-design
 category: Behavioral
 aliases: [EventStorming, Big Picture EventStorming, Process Modeling EventStorming, Design Level EventStorming]
 first_described: "Alberto Brandolini 2013"

--- a/patterns/11-domain-driven-design/factory.md
+++ b/patterns/11-domain-driven-design/factory.md
@@ -1,7 +1,7 @@
 ---
 name: Factory
 slug: factory
-family: 11-ddd
+family: 11-domain-driven-design
 category: Domain-Driven Design
 aliases: [Domain Factory, Aggregate Factory, Factory Method on Aggregate Root]
 first_described: "Evans 2003"

--- a/patterns/11-domain-driven-design/generic-subdomain.md
+++ b/patterns/11-domain-driven-design/generic-subdomain.md
@@ -1,7 +1,7 @@
 ---
 name: Generic Subdomain
 slug: generic-subdomain
-family: 11-ddd
+family: 11-domain-driven-design
 category: Strategic
 aliases: [Generic Domain, Commodity Subdomain, Buy-not-Build Subdomain]
 first_described: "Evans 2003"

--- a/patterns/11-domain-driven-design/layered-architecture.md
+++ b/patterns/11-domain-driven-design/layered-architecture.md
@@ -1,7 +1,7 @@
 ---
 name: Layered Architecture
 slug: layered-architecture
-family: 11-ddd
+family: 11-domain-driven-design
 category: Architectural
 aliases: [N-tier Architecture, Multilayer Architecture, Tiered Architecture, Presentation-Domain-Data Layering]
 first_described: "Buschmann, Meunier, Rohnert, Sommerlad, Stal 1996 (Pattern-Oriented Software Architecture, Volume 1)"

--- a/patterns/11-domain-driven-design/module.md
+++ b/patterns/11-domain-driven-design/module.md
@@ -1,7 +1,7 @@
 ---
 name: Module
 slug: module
-family: 11-ddd
+family: 11-domain-driven-design
 category: Domain-Driven Design
 aliases: [Package, Namespace, Bounded Context Internal Grouping]
 first_described: "Evans 2003"

--- a/patterns/11-domain-driven-design/open-host-service.md
+++ b/patterns/11-domain-driven-design/open-host-service.md
@@ -1,7 +1,7 @@
 ---
 name: Open Host Service
 slug: open-host-service
-family: 11-ddd
+family: 11-domain-driven-design
 category: Strategic Design
 aliases: [OHS, Public Host Interface, Open API Context Relationship]
 first_described: "Evans 2003"

--- a/patterns/11-domain-driven-design/process-manager.md
+++ b/patterns/11-domain-driven-design/process-manager.md
@@ -1,7 +1,7 @@
 ---
 name: Process Manager
 slug: process-manager
-family: 11-ddd
+family: 11-domain-driven-design
 category: Behavioral
 aliases: [Orchestrator, Saga Orchestrator, Central Coordinator]
 first_described: "Hohpe, Woolf 2003"

--- a/patterns/11-domain-driven-design/published-language.md
+++ b/patterns/11-domain-driven-design/published-language.md
@@ -1,7 +1,7 @@
 ---
 name: Published Language
 slug: published-language
-family: 11-ddd
+family: 11-domain-driven-design
 category: Domain-Driven Design, Strategic
 aliases: [Common Language for Integration, Canonical Exchange Format]
 first_described: "Evans 2003"

--- a/patterns/11-domain-driven-design/repository.md
+++ b/patterns/11-domain-driven-design/repository.md
@@ -1,7 +1,7 @@
 ---
 name: Repository
 slug: repository
-family: 11-ddd
+family: 11-domain-driven-design
 category: Domain-Driven Design
 aliases: [Repository Pattern, Persistence Repository, Collection-Oriented Repository]
 first_described: "Evans 2003 (Domain-Driven Design); Fowler, Rice, Foemmel, Hieatt, Mee, Stafford 2002 (Patterns of Enterprise Application Architecture)"

--- a/patterns/11-domain-driven-design/separate-ways.md
+++ b/patterns/11-domain-driven-design/separate-ways.md
@@ -1,7 +1,7 @@
 ---
 name: Separate Ways
 slug: separate-ways
-family: 11-ddd
+family: 11-domain-driven-design
 category: Strategic Design
 aliases: [SW, No Integration, Cut the Strings]
 first_described: "Evans 2003"

--- a/patterns/11-domain-driven-design/shared-kernel.md
+++ b/patterns/11-domain-driven-design/shared-kernel.md
@@ -1,7 +1,7 @@
 ---
 name: Shared Kernel
 slug: shared-kernel
-family: 11-ddd
+family: 11-domain-driven-design
 category: Strategic Design
 aliases: [Shared Kernel Context, Kernel Sharing]
 first_described: "Evans 2003"

--- a/patterns/11-domain-driven-design/specification.md
+++ b/patterns/11-domain-driven-design/specification.md
@@ -1,7 +1,7 @@
 ---
 name: Specification
 slug: specification
-family: 11-ddd
+family: 11-domain-driven-design
 category: Domain-Driven Design
 aliases: [Specification Pattern, Query Object composed with predicates, Business Rule Object]
 first_described: "Evans and Fowler 2002 (Specifications paper), Evans 2004"

--- a/patterns/11-domain-driven-design/supporting-subdomain.md
+++ b/patterns/11-domain-driven-design/supporting-subdomain.md
@@ -1,7 +1,7 @@
 ---
 name: Supporting Subdomain
 slug: supporting-subdomain
-family: 11-ddd
+family: 11-domain-driven-design
 category: Strategic Design
 aliases: [Supporting Domain, Supporting Component]
 first_described: "Evans 2003, formalized as a three-way split by Vernon 2013"

--- a/patterns/11-domain-driven-design/ubiquitous-language.md
+++ b/patterns/11-domain-driven-design/ubiquitous-language.md
@@ -1,7 +1,7 @@
 ---
 name: Ubiquitous Language
 slug: ubiquitous-language
-family: 11-ddd
+family: 11-domain-driven-design
 category: Strategic
 aliases: [Common Language, Shared Domain Vocabulary]
 first_described: "Evans 2003"

--- a/patterns/11-domain-driven-design/value-object.md
+++ b/patterns/11-domain-driven-design/value-object.md
@@ -1,7 +1,7 @@
 ---
 name: Value Object
 slug: value-object
-family: 11-ddd
+family: 11-domain-driven-design
 category: Domain-Driven Design
 aliases: [Value Type, Immutable Value, Whole Value]
 first_described: "Fowler and Evans, 2002 to 2003"

--- a/tools/gen-catalogue-status.py
+++ b/tools/gen-catalogue-status.py
@@ -38,7 +38,7 @@ FAMILY_ORIGIN = {
     "08-cloud-distributed": ("Cloud and Distributed", "Azure Architecture Center"),
     "09-concurrency": ("Concurrency and Parallelism", "Schmidt POSA 2"),
     "10-microservices": ("Microservices", "Richardson"),
-    "11-ddd": ("Domain-Driven Design", "Evans, Vernon"),
+    "11-domain-driven-design": ("Domain-Driven Design", "Evans, Vernon"),
     "12-data-storage": ("Data and Storage", "Kleppmann"),
     "13-frontend-ui": ("Frontend and UI", "Framework documentation"),
     "14-testing": ("Testing", "Meszaros, xUnit Test Patterns"),

--- a/tools/gen-indexes.py
+++ b/tools/gen-indexes.py
@@ -25,7 +25,7 @@ FAMILY_TITLES = {
     ),
     "09-concurrency": ("Concurrency and Parallelism", "Schmidt POSA 2"),
     "10-microservices": ("Microservices", "Richardson"),
-    "11-ddd": ("Domain-Driven Design", "Evans, Vernon"),
+    "11-domain-driven-design": ("Domain-Driven Design", "Evans, Vernon"),
     "12-data-storage": ("Data and Storage", "Kleppmann"),
     "13-frontend-ui": ("Frontend and UI", "Framework documentation"),
     "14-testing": ("Testing", "Meszaros, xUnit Test Patterns"),


### PR DESCRIPTION
## Summary

Rename family 11's folder slug from `11-ddd` to `11-domain-driven-design`, matching
the earlier `06-poeaa` -> `06-enterprise-application-architecture` rename (PR #135)
so no family folder uses an abbreviated slug.

## Scope

- `git mv patterns/11-ddd patterns/11-domain-driven-design`
- 33 pattern files' `family:` frontmatter updated
- `README.md`, `dist/catalogue-status.{json,csv}`, `docs/AUTHORING-QUEUE.json` updated
- `tools/gen-indexes.py` and `tools/gen-catalogue-status.py` family-slug maps updated

## Test plan

- [x] Exhaustive grep for `11-ddd`: zero remaining references
- [x] Structure gate: 395/395 pass (independently re-run)
- [x] Prose gate: 414/414 pass (independently re-run)
- [x] Reference gate: `validate-refs.py --strict`, all 2274 citations resolve
- [x] Code gate: `check-code.py`, 1345 compiled, 0 failed
- [x] markdownlint-cli2: 0 issues
- [x] Regen idempotency: two consecutive passes byte-identical
