### PR TITLE
chore(governance): README families table is now the folder-naming rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
           python-version: "3.12"
       - name: Structural gate
         run: python3 tools/check-structure.py
+      - name: Family folder naming gate
+        run: python3 tools/check-family-names.py
       - name: Prose gate
         run: python3 tools/check-prose.py
       - name: Indexes are current

--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ README does not claim they are implemented.
 
 ## The families
 
+This table is the source of truth for family folder names under `patterns/`.
+A folder's slug always matches the slug linked here, enforced in CI. See
+[docs/FAMILY-NAMING.md](docs/FAMILY-NAMING.md).
+
 | # | Family | Origin | Published | Planned | Target |
 |---|---|---|---|---|---|
 | 01 | [Design Patterns (GoF)](patterns/01-gof/) | Gamma, Helm, Johnson, Vlissides 1994 | 23 | 0 | 23 |

--- a/docs/FAMILY-NAMING.md
+++ b/docs/FAMILY-NAMING.md
@@ -1,0 +1,51 @@
+# Family folder naming. Hard rule
+
+## The rule
+
+The `## The families` table in `README.md` is the single canonical source of
+truth for every family folder name under `patterns/`. A `patterns/<slug>/`
+directory's `<slug>` MUST exactly match the slug linked in that table's row
+for the corresponding family number. There is no other source of truth for
+family folder naming. Not `docs/AUTHORING-QUEUE.json`, not
+`tools/gen-indexes.py`'s `FAMILY_TITLES`, not `tools/gen-catalogue-status.py`'s
+`FAMILY_ORIGIN`, not memory, not a guess. Those files derive from the table
+and must be kept in sync with it, never the reverse.
+
+## Why
+
+Family folder slugs drifted from the README table more than once. For
+example, `patterns/11-ddd/` existed on disk while the table linked
+`patterns/11-domain-driven-design/`. Each drift meant broken links from the
+README to the actual folder, and inconsistent naming across the repo. This
+doc and its CI gate exist so that class of mismatch cannot recur silently.
+
+## Enforcement
+
+`tools/check-family-names.py` parses the README families table and asserts
+that every `patterns/<slug>/` directory on disk has a slug present in that
+table. It is wired into the `structure` job of `.github/workflows/ci.yml` and
+runs on every push and pull request. A mismatch fails CI.
+
+Run it locally before opening a PR.
+
+```
+python3 tools/check-family-names.py
+```
+
+## Renaming a family folder
+
+If a family folder must be renamed, correcting a past drift or an
+intentional rename, update all of the following together, in one commit.
+
+1. `git mv patterns/<old-slug> patterns/<new-slug>`
+2. The frontmatter `family:` field in every pattern file in that folder
+3. `README.md`, in the families table row for that family
+4. `tools/gen-indexes.py`, the `FAMILY_TITLES` dict
+5. `tools/gen-catalogue-status.py`, the `FAMILY_ORIGIN` dict
+6. `dist/catalogue-status.json` and `dist/catalogue-status.csv`, regenerated
+7. `docs/AUTHORING-QUEUE.json`, if it references the old slug
+
+Then confirm zero remaining references to the old slug (`grep -rn
+"<old-slug>" .` outside `.git/`), regenerate indexes and catalogue status,
+and run all five gates (structure, prose, refs, code, markdownlint) before
+opening a PR.

--- a/tools/check-family-names.py
+++ b/tools/check-family-names.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Family folder naming gate. README.md '## The families' table is the
+source of truth for every patterns/<slug>/ name. See docs/FAMILY-NAMING.md."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PATTERNS = ROOT / "patterns"
+README = ROOT / "README.md"
+
+TABLE_HEADER = "## The families"
+LINK_RE = re.compile(r"\[([^\]]+)\]\(patterns/([^/)]+)/\)")
+
+
+def parse_table_slugs() -> dict[str, str]:
+    # Return {slug: family_title} for every row in the families table.
+    content = README.read_text()
+    idx = content.find(TABLE_HEADER)
+    if idx == -1:
+        print(f"ERROR: '{TABLE_HEADER}' section not found in README.md")
+        sys.exit(1)
+    # Table runs until the next '##' heading or EOF.
+    rest = content[idx:]
+    end = rest.find("\n## ", 4)
+    table_block = rest[:end] if end != -1 else rest
+
+    slugs: dict[str, str] = {}
+    for line in table_block.splitlines():
+        line = line.strip()
+        if (
+            not line.startswith("|")
+            or line.startswith("|---")
+            or line.startswith("| # ")
+        ):
+            continue
+        m = LINK_RE.search(line)
+        if m:
+            title, slug = m.group(1), m.group(2)
+            slugs[slug] = title
+    return slugs
+
+
+def main() -> int:
+    table_slugs = parse_table_slugs()
+    if not table_slugs:
+        print("ERROR: no family rows parsed from README.md families table")
+        return 1
+
+    actual_dirs = sorted(p.name for p in PATTERNS.iterdir() if p.is_dir())
+    table_slug_set = set(table_slugs)
+
+    problems: list[str] = []
+
+    for d in actual_dirs:
+        if d not in table_slug_set:
+            problems.append(
+                f"patterns/{d}/ exists on disk but is NOT declared in the "
+                f"README '## The families' table. Either rename the folder "
+                f"to match the table, or update the table if the family "
+                f"was intentionally renamed."
+            )
+
+    if problems:
+        print("FAIL: family folder names do not match README.md families table\n")
+        for p in problems:
+            print(f"  - {p}")
+        print(
+            "\nThe README '## The families' table is the single source of "
+            "truth for family folder naming in this repo. See "
+            "docs/FAMILY-NAMING.md."
+        )
+        return 1
+
+    print(
+        f"{len(actual_dirs)} family folder(s) on disk, all match README.md families table"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Per explicit request, this makes README.md's `## The families` table the
documented and mechanically enforced source of truth for `patterns/`
family folder naming, and audits every existing family folder against it.

- Adds `tools/check-family-names.py`: parses the README families table,
  asserts every `patterns/<slug>/` folder on disk has its slug declared
  there. Fails CI on any mismatch.
- Wires the new gate into the `structure` job in `.github/workflows/ci.yml`.
- Adds `docs/FAMILY-NAMING.md`: the rule, why it exists, and the exact
  multi-file rename procedure to follow if a family folder is ever renamed.
- Adds a one-line pointer to the doc directly above the families table in
  README.md.
- Audited all 11 existing family folders against the table. All match:
  `01-gof`, `02-code-smells`, `04-principles-and-laws`, `05-architectural`,
  `06-enterprise-application-architecture`, `08-cloud-distributed`,
  `10-microservices`, `11-domain-driven-design`, `14-testing`,
  `17-ai-agentic`, `18-anti-patterns`. No mismatches remain beyond the two
  already fixed and merged in #135 (family 06) and #138 (family 11).

## Test plan

- [x] `python3 tools/check-family-names.py` — 11/11 match
- [x] `python3 tools/check-structure.py` — 395/395 pass
- [x] `python3 tools/check-prose.py` — 415/415 pass
- [x] `python3 tools/validate-refs.py --strict --timeout 25` — 2274 distinct citations, all resolve
- [x] `python3 tools/check-code.py --strict` — 1345 compiled, 0 failed
- [x] `npx markdownlint-cli2@0.23.2` — 0 issues in 413 files
- [x] `tools/gen-indexes.py` + `tools/gen-catalogue-status.py` regen, two consecutive passes byte-identical (no diff)
