### PR TITLE
docs(patterns): add optional evidence confidence addendum

### DIFF
--- a/docs/ENTRY-TEMPLATE.md
+++ b/docs/ENTRY-TEMPLATE.md
@@ -145,6 +145,33 @@ Every source used, with author, title, edition or version, page or section, URL
 where one exists, and the date the URL was verified. Sources must be
 independently checkable by a reader.
 
+#### Evidence confidence (optional addendum)
+
+An author may close dimension 18 with a short, honest confidence tag on the
+entry's own sourcing, distinct from `maturity` in the frontmatter. `maturity`
+grades how settled the PATTERN is in industry. This addendum grades how solid
+the SOURCING behind this particular entry is, which can diverge, a contested
+pattern can still be sourced with high confidence, and a canonical one can
+still lean on a thin citation somewhere.
+
+```markdown
+**Evidence grade.** high | medium | low | mixed | unknown
+
+**Most solid findings.** One to three bullets naming the claims this entry is
+most confident in and why.
+
+**Unverified or unclear.** What still needs a closer source before it should
+be treated as settled fact, named plainly rather than smoothed over.
+```
+
+Optional, new-only. Existing entries are not retroactively required to carry
+it, and `tools/check-structure.py` does not enforce it, the same new-only
+posture as the advisory duplicate check. Adopted from the `evidence_grade` and
+`evidence_snapshot` convention in nibzard/awesome-agentic-patterns'
+`TEMPLATE.md`, adapted here as a documented addendum inside dimension 18
+rather than a frontmatter-only tag, since our dimension 18 already carries the
+per-source detail this confidence judgement sits beside.
+
 ## Code examples
 
 Every entry carries working code in at least three languages from this set.


### PR DESCRIPTION
## Summary

Adds an optional evidence-confidence addendum to dimension 18 (References) in docs/ENTRY-TEMPLATE.md. an entry-level evidence grade (high, medium, low, mixed, unknown) plus a most-solid-findings list and an unverified-or-unclear callout, distinct from the existing maturity frontmatter field, which grades the pattern's adoption in industry rather than this entry's own sourcing confidence.

Verified against the live source before adopting it. fetched nibzard/awesome-agentic-patterns TEMPLATE.md and two real pattern entries directly. the actual convention there is a whole-entry confidence tag with three parts (Evidence Grade, Most Valuable Findings, Unverified/Unclear), used inconsistently across their own repo (present in roughly half the entries checked, marked optional in their own template comment). It is NOT a per-citation field as an earlier characterization in this session had loosely described it, and there is no evidence_snapshot field distinct from the confidence summary, that name refers to the same short findings-plus-uncertainty text, not an archived link.

New-only. tools/check-structure.py is unmodified, REQUIRED_SECTIONS and REQUIRED_FRONTMATTER are unchanged, and the addendum is documented as optional prose inside dimension 18 rather than a new required dimension or frontmatter key, so none of the 797 published entries need retrofitting. Confirmed by running the structural gate after the change, 797/797 still pass, identical to before.

## Verification

- `check-structure.py`. 797/797 entries pass, unchanged
- `markdownlint-cli2@0.23.2`. 0 issues across all 829 tracked files
- Diff is docs-only, 27 lines added to docs/ENTRY-TEMPLATE.md, no pattern content or tooling touched

Not a required 19th dimension. the repository's own scope decision (recorded 2026-08-02 in ENTRY-TEMPLATE.md) fixed all entries at 18 dimensions with no lighter class, and adding a required dimension here would force a retrofit of all 797 published entries, which was not asked for and is out of scope for this change.
