### PR TITLE
fix(patterns) redraw eleven more ASCII diagrams under 78 columns

### DIFF
--- a/patterns/01-design-patterns-gof/README.md
+++ b/patterns/01-design-patterns-gof/README.md
@@ -2,7 +2,7 @@
 
 Origin. Gamma, Helm, Johnson, Vlissides 1994
 
-32 entries, 306,344 words, 1 more planned, 33 total when the family is complete. Every entry carries all 18
+32 entries, 306,354 words, 1 more planned, 33 total when the family is complete. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Behavioral
@@ -46,7 +46,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Extension Object](extension-object.md) | established | 6,186 | Some abstractions cannot have their full, final interface anticipated at design time, because different clients of the same class genuinely need different views onto it. |
 | [Facade](facade.md) | canonical | 11,164 | A caller needs a small, ordinary result from a subsystem that is large, correct and unpleasant to talk to. |
 | [Flyweight](flyweight.md) | canonical | 11,738 | A program needs a very large number of objects that are almost all the same, and the memory cost of representing each one separately is what is going to break it. |
-| [Marker Interface](marker-interface.md) | contested | 5,201 | Sometimes a class needs to signal a capability or a semantic property to an external mechanism, most often the runtime or a framework, without adding any real behaviour of its own. |
+| [Marker Interface](marker-interface.md) | contested | 5,211 | Sometimes a class needs to signal a capability or a semantic property to an external mechanism, most often the runtime or a framework, without adding any real behaviour of its own. |
 | [Private Class Data](private-class-data.md) | contested | 6,549 | SourceMaking's own "Problem" section states the target of the pattern directly. |
 | [Proxy](proxy.md) | canonical | 9,732 | Some object is expensive, remote, dangerous, or shared, and the code that wants to use it should not have to know that. |
 | [Role Object](role-object.md) | established | 8,705 | A single key abstraction is used from more than one context, and each context needs its own, different view of it. |

--- a/patterns/01-design-patterns-gof/marker-interface.md
+++ b/patterns/01-design-patterns-gof/marker-interface.md
@@ -54,30 +54,37 @@ Do not reach for a marker interface when the tag needs to carry data now or is l
 ## 6. ASCII structure diagram
 
 ```
-+----------------------------+
-|      <<marker interface>>   |
-|      java.io.Serializable   |
-|------------------------------|
-|      (no members)           |
-+---------------^--------------+
-                |
-                | implements, alongside other markers
-                |
-+---------------+----------------------------------------+
-|                java.util.ArrayList<E>                    |
-|------------------------------------------------------------|
-|  implements List<E>, RandomAccess, Cloneable, Serializable |
-+------------------------------------------------------------+
++----------------------+
+| <<marker interface>> |
+| java.io.Serializable |
+| (no members)         |
++----------------------+
+           ^
+           | implements, alongside other markers
+           |
++-----------------------------------+
+| java.util.ArrayList<E>            |
+| implements List<E>, RandomAccess, |
+| Cloneable, Serializable           |
++-----------------------------------+
 
-+------------------------------+          checks           +----------------------------+
-|  java.io.ObjectOutputStream   |--------------------------->|  instanceof Serializable?   |
-|  writeObject(Object obj)      |                            +--------------+---------------+
-+------------------------------+                                            |
-                                                                   yes       |       no
-                                                          +-----------------+------------------+
-                                                          v                                      v
-                                              object is serialized                 java.io.NotSerializableException
-                                                                                    is thrown, naming the class
+Serialization check, at write time:
+
++----------------------------+
+| java.io.ObjectOutputStream |
+| writeObject(Object obj)    |
++----------------------------+
+           |
+           | checks
+           v
++--------------------------+
+| instanceof Serializable? |
++--------------------------+
+        yes |    | no
+      +-----+    +-----+
+      v                v
+object is       NotSerializableException
+serialized      is thrown, naming the class
 ```
 
 ## 7. Dynamics

--- a/patterns/04-principles-and-laws/README.md
+++ b/patterns/04-principles-and-laws/README.md
@@ -2,7 +2,7 @@
 
 Origin. Martin, Larman, Brewer, Conway
 
-42 entries, 327,284 words. Every entry carries all 18
+42 entries, 327,293 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Design Principle
@@ -33,7 +33,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Common Closure Principle](common-closure-principle.md) | canonical | 7,574 | A codebase reaches the size where a single flat namespace of classes stops being a unit anyone can reason about, and the team splits it into smaller compilation and deployment ... |
 | [Composition over Inheritance](composition-over-inheritance.md) | canonical | 6,930 | A designer needs an object to have several independent, combinable behaviours, and reaches for a single class hierarchy to express all of them. |
 | [Controller](controller.md) | canonical | 6,874 | A team wiring a new interaction into an object-oriented system reaches a concrete, recurring question the moment a user clicks a button, submits a form, or an external system ... |
-| [Conway's Law](conway-law.md) | canonical | 7,740 | A team is asked to build a system with several distinct concerns. |
+| [Conway's Law](conway-law.md) | canonical | 7,751 | A team is asked to build a system with several distinct concerns. |
 | [Creator](creator.md) | canonical | 7,514 | Every object-oriented system eventually needs a new object of type A to come into existence somewhere, and the code that calls the constructor has to live in some class B. |
 | [Do Not Repeat Yourself](do-not-repeat-yourself.md) | canonical | 6,449 | A single fact about the system, a tax rate, a validation rule, a URL, a unit conversion, a business rule about who is allowed to approve a refund, gets written down in more than ... |
 | [Fail Fast](fail-fast.md) | established | 7,090 | A running program encounters a state it was not written to handle correctly. |
@@ -45,7 +45,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Keep It Simple](keep-it-simple.md) | canonical | 8,079 | Every non-trivial piece of software accretes complexity over its lifetime, and that accretion happens in two very different ways that are easy to conflate. |
 | [Law of Demeter](law-of-demeter.md) | canonical | 7,910 | A method reaches through an object it was handed to get at a second object, then calls a method on that second object. |
 | [Low Coupling](low-coupling.md) | canonical | 7,299 | Every nontrivial system is built from more than one unit of code, whether those units are classes in one process, packages in one codebase, or services across a network. |
-| [Open Closed Principle](open-closed-principle.md) | canonical | 5,600 | A piece of software that ships once and never changes does not need this principle. |
+| [Open Closed Principle](open-closed-principle.md) | canonical | 5,598 | A piece of software that ships once and never changes does not need this principle. |
 | [PACELC Theorem](pacelc-theorem.md) | canonical | 9,039 | A team picks a distributed database, reads that it is "AP" or "CP" under CAP, and believes that single letter fully describes how the system will behave in production. |
 | [Postel's Law](postel-law.md) | contested | 8,891 | Two or more parties implement the same open, published specification independently, without coordinating their release schedules, their source code, or in most cases even knowing ... |
 | [Principle of Least Astonishment](principle-of-least-astonishment.md) | canonical | 9,080 | A person interacts with a piece of software, whether by reading its code, by calling its API, by typing a command at a shell, or by clicking a button in a user interface, and ... |

--- a/patterns/04-principles-and-laws/conway-law.md
+++ b/patterns/04-principles-and-laws/conway-law.md
@@ -249,29 +249,48 @@ rather than code-level actors.
 ## 6. ASCII structure diagram
 
 ```
-  ORGANIZATION                          SYSTEM
-  (communication graph)                 (module dependency graph)
+ORGANIZATION (communication graph)
 
-  +-----------+   frequent    +-----------+       +-----------+  rich, informal  +-----------+
-  |  Team A   |<------------->|  Team B   |       | Module A  |<---------------->| Module B  |
-  | (Billing) |   contact     | (Ledger)  |       | (Billing) |   interface      | (Ledger)  |
-  +-----------+               +-----------+       +-----------+                  +-----------+
-        ^                            ^                   ^                             ^
-        | rare, formal contact       |                   | brittle, versioned,          |
-        | (different offices,        |                   | defensively specified        |
-        |  different managers)       |                   | interface                    |
-        v                            v                   v                             v
-  +-----------+   rare        +-----------+       +-----------+   brittle, versioned  +-----------+
-  |  Team C   |<------------->|  Team D   |       | Module C  |<---------------------->| Module D  |
-  | (Search)  |   quarterly   | (Public   |       | (Search)  |                        | (Public   |
-  |           |   sync only   |   API)    |       |           |                        |   API)    |
-  +-----------+               +-----------+       +-----------+                        +-----------+
++-----------+            +----------+
+| Team A    |            | Team B   |
+| (Billing) | <--------> | (Ledger) |
++-----------+            +----------+
+     ^                    ^
+     | rare, formal contact
+     | (different offices, different managers)
+     v                    v
++----------+            +--------------+
+| Team C   |            | Team D       |
+| (Search) | <--------> | (Public API) |
++----------+            +--------------+
 
-  The organizational edge (top) and the module dependency edge (top) are both
-  frequent and rich. The organizational edge (bottom) and the module
-  dependency edge (bottom) are both rare and brittle. Conway's Law is the
-  claim that this correspondence is not a coincidence, it is causal, running
-  from the top row to the bottom row.
+Team A <-> Team B: frequent contact
+Team C <-> Team D: rare, quarterly sync only
+
+SYSTEM (module dependency graph)
+
++-----------+        +----------+
+| Module A  |        | Module B |
+| (Billing) | <----> | (Ledger) |
++-----------+        +----------+
+      ^                   ^
+      | brittle, versioned,
+      | defensively specified interface
+      v                   v
++----------+        +--------------+
+| Module C |        | Module D     |
+| (Search) | <----> | (Public API) |
++----------+        +--------------+
+
+Module A <-> Module B: rich, informal interface
+Module C <-> Module D: brittle, versioned interface
+
+The organizational edge A-B and the module dependency edge
+A-B are both frequent and rich. The organizational edge C-D
+and the module dependency edge C-D are both rare and
+brittle. Conway's Law is the claim that this correspondence
+is not a coincidence, it is causal, running from the
+organization to the system.
 ```
 
 ## 7. Dynamics

--- a/patterns/04-principles-and-laws/open-closed-principle.md
+++ b/patterns/04-principles-and-laws/open-closed-principle.md
@@ -197,27 +197,33 @@ the system rather than distributed through every consumer.
 ## 6. ASCII structure diagram
 
 ```
-+-------------------+          uses           +---------------------+
-|      Client       | ----------------------> |     Abstraction      |
-| (never edited to   |                         |   <<interface>>      |
-|  add a new variant) |                        |  operation()          |
-+-------------------+                          +---------------------+
-                                                          ^
-                                                          | implements
-                          +-------------------------------+-------------------------------+
-                          |                                |                               |
-              +---------------------+        +---------------------+       +---------------------+
-              | ConcreteImpl A       |        | ConcreteImpl B       |       | ConcreteImpl C (new) |
-              | operation()          |        | operation()          |       | operation()           |
-              +---------------------+        +---------------------+       +---------------------+
-                          ^                                ^                               ^
-                          +----------------+---------------+---------------+----------------+
-                                           wired by
-                                   +---------------------+
-                                   |  Composition Root     |
-                                   |  (knows every variant, |
-                                   |   only place that does) |
-                                   +---------------------+
++-------------------------------------+
+| Client                              |
+| (never edited to add a new variant) |
++-------------------------------------+
+           | uses
+           v
++----------------------------+
+| Abstraction  <<interface>> |
+| operation()                |
++----------------------------+
+           ^
+           | implements
+     +-----+-----+-----+
+     |           |     |
++---------------------+ +---------------------+ +---------------------+
+| ConcreteImpl A      | | ConcreteImpl B      | | ConcreteImpl C (new)|
+| operation()         | | operation()         | | operation()         |
++---------------------+ +---------------------+ +---------------------+
+     ^           ^     ^
+     +-----+-----+-----+
+           | wired by
+           v
++-----------------------+
+| Composition Root      |
+| (knows every variant, |
+| only place that does) |
++-----------------------+
 ```
 
 ## 7. Dynamics

--- a/patterns/06-enterprise-application-architecture/README.md
+++ b/patterns/06-enterprise-application-architecture/README.md
@@ -2,7 +2,7 @@
 
 Origin. Fowler, PoEAA
 
-56 entries, 371,878 words, 4 more planned, 60 total when the family is complete. Every entry carries all 18
+56 entries, 371,855 words, 4 more planned, 60 total when the family is complete. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Base Pattern
@@ -17,7 +17,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
-| [Mapper](mapper.md) | canonical | 5,400 | Two subsystems need to exchange information, but neither one should hold a compile time or a conceptual dependency on the other's shape. |
+| [Mapper](mapper.md) | canonical | 5,386 | Two subsystems need to exchange information, but neither one should hold a compile time or a conceptual dependency on the other's shape. |
 
 ## Base Patterns
 
@@ -154,7 +154,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Page Controller](page-controller.md) | canonical | 5,225 | A web application must translate an incoming HTTP request into a specific piece of server-side behavior and a specific response. |
 | [Template View](template-view.md) | canonical | 7,530 | A system has finished computing a result, a customer record, a list of orders, a search result set, and now has to turn that result into an HTML document a browser can render. |
 | [Transform View](transform-view.md) | established | 7,578 | An application has assembled everything it needs to render a response. |
-| [Two Step View](two-step-view.md) | canonical | 6,245 | A web application with more than a handful of pages needs every page to share a consistent visual identity. |
+| [Two Step View](two-step-view.md) | canonical | 6,236 | A web application with more than a handful of pages needs every page to share a consistent visual identity. |
 
 ## Planned
 

--- a/patterns/06-enterprise-application-architecture/mapper.md
+++ b/patterns/06-enterprise-application-architecture/mapper.md
@@ -173,22 +173,35 @@ composes with rather than requires.
 ## 6. ASCII structure diagram
 
 ```
-+-----------------+          +-----------------+          +-----------------+
-|      Source       |          |      Mapper       |          |      Target       |
-|  (e.g. domain      |          |  knows both        |          |  (e.g. relational  |
-|   object, has no    | <------ |  shapes, holds      | ------> |   row, has no      |
-|   knowledge of        |         |  the translation    |         |   knowledge of      |
-|   Target)                |         |  logic                  |         |   Source)                |
-+-----------------+          +-----------------+          +-----------------+
-                                     |
-                                     |  optionally collaborates with
-                                     v
-                  +------------------+     +------------------+
-                  |   Identity Map     |     |   Unit of Work     |
-                  |  one in-memory      |     |  batches pending    |
-                  |  object per row      |     |  inserts, updates,   |
-                  |                       |     |  deletes              |
-                  +------------------+     +------------------+
++-----------------------------+
+| Source                      |
+| (e.g. domain object, has no |
+| knowledge of Target)        |
++-----------------------------+
+           ^
+           |
+           v
++-----------------------------+
+| Mapper                      |
+| knows both shapes,          |
+| holds the translation logic |
++-----------------------------+
+           ^
+           |
+           v
++------------------------------+
+| Target                       |
+| (e.g. relational row, has no |
+| knowledge of Source)         |
++------------------------------+
+
+Mapper optionally collaborates with:
+
++---------------------------+  +---------------------------+
+| Identity Map              |  | Unit of Work              |
+| one in-memory object      |  | batches pending           |
+| per row                   |  | inserts, updates, deletes |
++---------------------------+  +---------------------------+
 ```
 
 ## 7. Dynamics

--- a/patterns/06-enterprise-application-architecture/two-step-view.md
+++ b/patterns/06-enterprise-application-architecture/two-step-view.md
@@ -196,29 +196,31 @@ between them.
 ## 6. ASCII structure diagram
 
 ```
-+------------------+        builds        +----------------+
-|  Domain Model     | --------------------> |  Logical Page   |
-|  (order, invoice, |                       |  Builder         |
-|   article, ...)   |                       +--------+---------+
-+------------------+                                  |
-                                                        | produces
-                                                        v
-                                              +----------------------+
-                                              |   Logical Page        |
-                                              |   (presentation-      |
-                                              |    neutral tree or    |
-                                              |    XML vocabulary)    |
-                                              +-----------+----------+
-                                                            |
-                                    +-----------------------+------------------------+
-                                    |                                                |
-                                    v                                                v
-                          +------------------+                             +------------------+
-                          |  HTML Formatter    |                             |  PDF/Text Formatter |
-                          +--------+---------+                             +--------+---------+
-                                    |                                                |
-                                    v                                                v
-                             HTML response                               PDF or plain-text response
++--------------------------------+
+| Domain Model                   |
+| (order, invoice, article, ...) |
++--------------------------------+
+           | builds
+           v
++----------------------+
+| Logical Page Builder |
++----------------------+
+           | produces
+           v
++----------------------------+
+| Logical Page               |
+| (presentation-neutral tree |
+| or XML vocabulary)         |
++----------------------------+
+           |
+     +-----+-----+
+     |           |
++----------------------+  +----------------------+
+| HTML Formatter       |  | PDF/Text Formatter   |
++----------------------+  +----------------------+
+     |           |
+     v           v
+HTML response   PDF or plain-text response
 ```
 
 ## 7. Dynamics

--- a/patterns/07-integration/README.md
+++ b/patterns/07-integration/README.md
@@ -2,7 +2,7 @@
 
 Origin. Hohpe and Woolf
 
-54 entries, 385,772 words. Every entry carries all 18
+54 entries, 385,760 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Enterprise Integration
@@ -48,9 +48,9 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Content Enricher](content-enricher.md) | canonical | 6,840 | A message arrives at an integration point carrying less data than the next step needs. |
 | [Content Filter](content-filter.md) | canonical | 8,464 | A consumer receives a message that is far larger, richer, or more deeply nested than anything it needs, and forwarding or storing that full message creates real cost. |
 | [Correlation Identifier](correlation-identifier.md) | canonical | 7,467 | A process sends a message and does not receive its answer over the same connection it used to send it. |
-| [Document Message](document-message.md) | canonical | 7,022 | Two systems need to exchange a structured record, such as a customer record, a purchase order, a lab result, or a shipment manifest. |
+| [Document Message](document-message.md) | canonical | 7,017 | Two systems need to exchange a structured record, such as a customer record, a purchase order, a lab result, or a shipment manifest. |
 | [Dynamic Router](dynamic-router.md) | canonical | 7,649 | A message-routing component in a system needs to send a message onward, and the set of places it might send that message to is not fixed at the time the router is built, deployed ... |
-| [Event Message](event-message.md) | canonical | 7,042 | An application performs an action that other applications, possibly ones the first application has never heard of and will never know about, need to react to. |
+| [Event Message](event-message.md) | canonical | 7,035 | An application performs an action that other applications, possibly ones the first application has never heard of and will never know about, need to react to. |
 | [Event-Driven Consumer](event-driven-consumer.md) | canonical | 6,039 | A service needs to react when something happens elsewhere in the system, a payment is captured, an order is placed, a file lands in a bucket, a row is updated in another team's ... |
 | [Format Indicator](format-indicator.md) | canonical | 6,130 | A message travels from a producer to a consumer, and at some point the consumer must decide how to parse the bytes it received. |
 | [Message](message.md) | canonical | 6,901 | Two applications need to exchange information without either one blocking on the other's availability, without either one dictating the other's internal data model, and without a ... |

--- a/patterns/07-integration/document-message.md
+++ b/patterns/07-integration/document-message.md
@@ -226,24 +226,28 @@ still agreeing on meaning.
 ## 6. ASCII structure diagram
 
 ```
-+-----------+        Document Message         +--------------------+
-| Producer  | ------------------------------> | Message Channel     |
-| (holds    |  { schema-typed data payload }  | (point-to-point or  |
-|  the data)|                                 |  publish-subscribe) |
-+-----------+                                 +----------+----------+
-                                                          |
-                          +-------------------------------+-------------------------------+
-                          |                                                               |
-                          v                                                               v
-                 +-----------------+                                             +-----------------+
-                 |   Consumer A    |                                             |   Consumer B     |
-                 | interprets the  |                                             | interprets the   |
-                 | document in its |                                             | document in its  |
-                 | own domain      |                                             | own domain       |
-                 +-----------------+                                             +-----------------+
++---------------------------+
+| Producer (holds the data) |
++---------------------------+
+           | Document Message
+           | { schema-typed data payload }
+           v
++---------------------------------------+
+| Message Channel                       |
+| (point-to-point or publish-subscribe) |
++---------------------------------------+
+           |
+     +-----+-----+
+     |           |
++---------------------+ +---------------------+
+| Consumer A          | | Consumer B          |
+| interprets the      | | interprets the      |
+| document in its     | | document in its     |
+| own domain          | | own domain          |
++---------------------+ +---------------------+
 
-                 Producer knows only that a well-formed <Type> document was published.
-                 Producer does NOT know or care what A or B do with it.
+Producer knows only that a well-formed <Type> document was
+published. Producer does NOT know or care what A or B do with it.
 ```
 
 ## 7. Dynamics

--- a/patterns/07-integration/event-message.md
+++ b/patterns/07-integration/event-message.md
@@ -222,28 +222,31 @@ Do NOT reach for Event Message when.
 ## 6. ASCII structure diagram
 
 ```
-+------------------+         publishes         +------------------+
-|   Producer        |  ----------------------->  |      Channel      |
-|  (Event Source)    |    Event Message(s)       |  (topic / stream / |
-|                    |                            |   pub-sub bus)     |
-+------------------+                             +---------+----------+
-                                                             |
-                                     fan-out (0..N)          |
-                          +----------------------------------+---------------------------+
-                          |                                  |                           |
-                          v                                  v                           v
-                 +----------------+                 +----------------+          +----------------+
-                 |  Consumer A     |                 |  Consumer B     |          |  Consumer N     |
-                 | (e.g. Billing)  |                 | (e.g. Inventory)|          | (e.g. Analytics)|
-                 +--------+--------+                 +--------+--------+          +--------+--------+
-                          |                                    |                             |
-                 handler fails after retries         handler succeeds              handler succeeds
-                          |
-                          v
-                 +----------------+
-                 | Dead Letter     |
-                 |   Channel       |
-                 +----------------+
++-------------------------+
+| Producer (Event Source) |
++-------------------------+
+           | publishes Event Message(s)
+           v
++--------------------------------+
+| Channel                        |
+| (topic / stream / pub-sub bus) |
++--------------------------------+
+           |
+           | fan-out (0..N)
+     +-----+-----+-----+
+     |           |     |
++---------------------+ +---------------------+ +---------------------+
+| Consumer A          | | Consumer B          | | Consumer N          |
+| (e.g. Billing)      | | (e.g. Inventory)    | | (e.g. Analytics)    |
++---------------------+ +---------------------+ +---------------------+
+     |
+     | handler fails after retries
+     v
++---------------------+
+| Dead Letter Channel |
++---------------------+
+
+(Consumer B and Consumer N: handler succeeds)
 ```
 
 ## 7. Dynamics

--- a/patterns/12-data-storage/README.md
+++ b/patterns/12-data-storage/README.md
@@ -2,7 +2,7 @@
 
 Origin. Kleppmann
 
-45 entries, 319,858 words. Every entry carries all 18
+45 entries, 319,799 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Concurrency Control
@@ -41,8 +41,8 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Denormalization](denormalization.md) | canonical | 1,923 | The normalization article states directly why a fully normalized schema exists in the first place, and denormalization is the deliberate trade against exactly this protection. |
 | [Distributed Hash Table](distributed-hash-table.md) | canonical | 1,561 | A centralized lookup directory is a single point of failure and a single scaling bottleneck, every lookup depends on that one directory staying up and staying fast as the number ... |
 | [ELT](elt.md) | established | 7,149 | A team needs data from several operational systems, a payments database, a support ticket system, a marketing platform's API, a stream of application events, made available for ... |
-| [ETL](etl.md) | canonical | 7,257 | An organization has data that lives in one shape, in one place, produced for one purpose, and it needs that data in a different shape, in a different place, usable for a different ... |
-| [Gossip Protocol](gossip-protocol.md) | canonical | 9,789 | A set of processes, potentially numbering in the hundreds or thousands, needs to keep a piece of shared state consistent, or needs to agree on who is currently alive, without a ... |
+| [ETL](etl.md) | canonical | 7,204 | An organization has data that lives in one shape, in one place, produced for one purpose, and it needs that data in a different shape, in a different place, usable for a different ... |
+| [Gossip Protocol](gossip-protocol.md) | canonical | 9,783 | A set of processes, potentially numbering in the hundreds or thousands, needs to keep a piece of shared state consistent, or needs to agree on who is currently alive, without a ... |
 | [Hinted Handoff](hinted-handoff.md) | canonical | 5,677 | A leaderless, replicated key-value store assigns each key to a fixed set of N nodes, typically the next N nodes clockwise on a consistent-hashing ring. |
 | [Kappa Architecture](kappa-architecture.md) | established | 6,510 | A team running analytics or derived views over an event stream commonly starts with a batch pipeline. |
 | [LSM Tree](lsm-tree.md) | canonical | 9,064 | A key-value or wide-column store needs to sustain a high rate of writes, including writes that touch keys scattered across the entire key space, while still answering point ... |

--- a/patterns/12-data-storage/etl.md
+++ b/patterns/12-data-storage/etl.md
@@ -254,41 +254,41 @@ of the most common questions asked of any analytical pipeline.
 ## 6. ASCII structure diagram
 
 ```
-+-------------+     +-------------+     +---------------+     +-------------+     +---------------+
-|   Source A  |     |   Source B  |     |   Source C    |     |    ...      |     |               |
-| (OLTP DB)   |     | (SaaS API)  |     | (event logs)  |     |             |     |               |
-+------+------+     +------+------+     +-------+-------+     +------+------+     |               |
-       |                    |                    |                    |          |               |
-       v                    v                    v                    v          |               |
-+------------------------------------------------------------------------+       |               |
-|                            EXTRACTOR (per source connector)             |       | Orchestrator  |
-+------------------------------------------------------------------------+       | (schedules,   |
-                                     |                                            |  retries,     |
-                                     v                                            |  dependency   |
-                            +-----------------+                                  |  graph,       |
-                            |  Staging area   |                                  |  run history) |
-                            |  (raw, landed)  |                                  |               |
-                            +--------+--------+                                  |               |
-                                     |                                            |               |
-                                     v                                            |               |
-                            +-----------------+                                  |               |
-                            |   TRANSFORMER   |<---------------------------------+               |
-                            | (clean, conform,|                                  |               |
-                            |  dedup, model)  |                                  |               |
-                            +--------+--------+                                  |               |
-                                     |                                            |               |
-                                     v                                            |               |
-                            +-----------------+                                  |               |
-                            |     LOADER      |                                  |               |
-                            | (upsert / swap) |                                  |               |
-                            +--------+--------+                                  |               |
-                                     |                                            |               |
-                                     v                                            +---------------+
-                            +-----------------+
-                            |  Destination    |
-                            | (warehouse /    |
-                            |  lake / mart)   |
-                            +-----------------+
++---------------+ +---------------+ +---------------+
+| Source A      | | Source B      | | Source C      |
+| (OLTP DB)     | | (SaaS API)    | | (event logs)  |
++---------------+ +---------------+ +---------------+
+    |            |            |
+    +------------+------------+
+                 v
++----------------------------------+
+| EXTRACTOR (per source connector) |
++----------------------------------+
+                 v
++----------------------------+
+| Staging area (raw, landed) |
++----------------------------+
+                 v
++--------------------------------+
+| TRANSFORMER                    |
+| (clean, conform, dedup, model) |
++--------------------------------+
+                 v
++------------------------+
+| LOADER (upsert / swap) |
++------------------------+
+                 v
++---------------------------+
+| Destination               |
+| (warehouse / lake / mart) |
++---------------------------+
+
++----------------------------------------------------+
+| Orchestrator                                       |
+| schedules, retries, dependency graph, run history. |
+| Drives EXTRACTOR and TRANSFORMER above, not shown  |
+| as separate arrows to keep the flow readable.      |
++----------------------------------------------------+
 ```
 
 ## 7. Dynamics

--- a/patterns/12-data-storage/gossip-protocol.md
+++ b/patterns/12-data-storage/gossip-protocol.md
@@ -276,33 +276,47 @@ implementation has something filling each role.
 ## 6. ASCII structure diagram
 
 ```
-   +----------------------+          random peer          +----------------------+
-   |        Node A        |------------------------------->|        Node B        |
-   |----------------------|      gossip message, push,     |----------------------|
-   | LocalState            |      pull, or push-pull        | LocalState            |
-   |  - key/version pairs  |<-------------------------------| - key/version pairs  |
-   |----------------------|                                 |----------------------|
-   | PeerList (bounded)    |                                 | PeerList (bounded)    |
-   |  A, C, E, F ...        |                                 |  B, D, F, G ...        |
-   |----------------------|                                 |----------------------|
-   | Reconciler (merge)     |                                 | Reconciler (merge)     |
-   |----------------------|                                 |----------------------|
-   | FailureDetector        |                                 | FailureDetector        |
-   +----------------------+                                 +----------------------+
-             |                                                          |
-             |  each node independently, on its own timer, repeats.    |
-             |  select random peer, exchange, merge, update peer list, |
-             |  sleep(gossip_interval), repeat.                        |
-             v                                                          v
-   +----------------------+                                 +----------------------+
-   |        Node C          |<--- eventually reached  ------->|        Node D          |
-   |  (learns A's update     |     through multi-hop            |  (learns A's update     |
-   |   via B or another        |     relay, not a direct link     |   via C or another        |
-   |   intermediary)             |     from A)                     |   intermediary)              |
-   +----------------------+                                 +----------------------+
++--------------------------+
+| Node A                   |
+| ------------------------ |
+| LocalState               |
+|  - key/version pairs     |
+| PeerList (bounded)       |
+|  A, C, E, F ...          |
+| Reconciler (merge)       |
+| FailureDetector          |
++--------------------------+
+     |
+     | random peer, gossip message, push, pull, or push-pull
+     v
++--------------------------+
+| Node B                   |
+| ------------------------ |
+| LocalState               |
+|  - key/version pairs     |
+| PeerList (bounded)       |
+|  B, D, F, G ...          |
+| Reconciler (merge)       |
+| FailureDetector          |
++--------------------------+
 
-   No node has a global view. Every node's PeerList is a small, local,
-   partial sample of the whole membership, refreshed by gossip traffic.
+Each node independently, on its own timer, repeats: select
+random peer, exchange, merge, update peer list,
+sleep(gossip_interval), repeat.
+
++----------------------+         +----------------------+
+| Node C               |         | Node D               |
+| (learns A's update   |         | (learns A's update   |
+| via B or another     | <---> | via C or another     |
+| intermediary)        |         | intermediary)        |
++----------------------+         +----------------------+
+
+(eventually reached through multi-hop relay, not a
+ direct link from A)
+
+No node has a global view. Every node's PeerList is a
+small, local, partial sample of the whole membership,
+refreshed by gossip traffic.
 ```
 
 ## 7. Dynamics

--- a/patterns/14-testing/README.md
+++ b/patterns/14-testing/README.md
@@ -2,7 +2,7 @@
 
 Origin. Meszaros, xUnit Test Patterns
 
-30 entries, 217,056 words. Every entry carries all 18
+30 entries, 217,016 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Test Data
@@ -34,7 +34,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Approval Test](approval-test.md) | established | 7,682 | Consider a function that renders an invoice as HTML, a compiler pass that lowers an abstract syntax tree to bytecode, a report generator that produces a multi-page PDF summary, or ... |
 | [Arrange-Act-Assert](arrange-act-assert.md) | canonical | 6,255 | A test that has no imposed shape tends to accrete in whatever order the writer thought of things. |
 | [Characterization Test](characterization-test.md) | canonical | 6,420 | A team inherits a module, a service, or a whole codebase with no tests, or with tests too sparse to trust. |
-| [Contract Test](contract-test.md) | canonical | 8,408 | A team splits a monolith into services, or simply has two teams shipping two deployables that talk over HTTP, gRPC, or a message queue. |
+| [Contract Test](contract-test.md) | canonical | 8,368 | A team splits a monolith into services, or simply has two teams shipping two deployables that talk over HTTP, gRPC, or a message queue. |
 | [Differential Testing](differential-testing.md) | established | 7,373 | A team owns, or depends on, more than one thing that is meant to compute the same answer. |
 | [Fault Injection](fault-injection.md) | established | 7,609 | Software that talks to another process over a network, a disk, a database connection, or any other boundary will eventually see that boundary fail. |
 | [Fresh Fixture](fresh-fixture.md) | canonical | 7,305 | A test needs an environment in which to run its assertions, objects to act on, data in a database, files on disk, a running process. |

--- a/patterns/14-testing/contract-test.md
+++ b/patterns/14-testing/contract-test.md
@@ -226,56 +226,59 @@ generated identifiers, while still asserting the shape is correct.
 ## 6. ASCII structure diagram
 
 ```
-                     CONSUMER-DRIVEN VARIANT (Pact-style)
+CONSUMER-DRIVEN VARIANT (Pact-style)
 
-  +------------------+                         +------------------+
-  |    Consumer      |                         |    Provider      |
-  |   (Service A)    |                         |   (Service B)    |
-  |                  |                         |                  |
-  |  consumer test   |                         |  provider verify |
-  |  suite runs       |                         |  step runs        |
-  |  against a mock   |                         |  against REAL      |
-  |  of Service B     |                         |  Service B code    |
-  +--------+---------+                         +---------+--------+
-           |                                             |
-           | 1. records interactions                     | 3. replays every
-           |    request shape,                            |    interaction from
-           |     expected response                         |    every consumer
-           v                                               |    contract, asserts
-  +------------------+   2. publish contract   +----------v-------+
-  |  Contract file    |------------------------>|   Pact Broker    |
-  |  JSON, versioned   |                        |  contract store, |
-  +------------------+                          |  verify results, |
-                                                 |  can-i-deploy     |
-                                                 +---------+--------+
-                                                            |
-                                                            | 4. CI on both sides
-                                                            |    queries broker
-                                                            |    before deploy
-                                                            v
-                                                 +------------------+
-                                                 |  Deploy gate,    |
-                                                 |  can-i-deploy?   |
-                                                 +------------------+
++----------------------------------+
+| Consumer (Service A)             |
+| consumer test suite runs against |
+| a mock of Service B              |
++----------------------------------+
+           | 1. records interactions:
+           |    request shape, expected response
+           v
++--------------------------------+
+| Contract file, JSON, versioned |
++--------------------------------+
+           | 2. publish contract
+           v
++----------------------------------------------+
+| Pact Broker                                  |
+| contract store, verify results, can-i-deploy |
++----------------------------------------------+
+           ^
+           | 3. provider replays every interaction from
+           |    every consumer contract, asserts against
+           |    REAL Service B code
++----------------------+
+| Provider (Service B) |
+| provider verify step |
++----------------------+
+
+           | 4. CI on both sides queries broker before deploy
+           v
++----------------------------+
+| Deploy gate, can-i-deploy? |
++----------------------------+
 
 
-                  SPECIFICATION-DRIVEN VARIANT (OpenAPI / proto)
+SPECIFICATION-DRIVEN VARIANT (OpenAPI / proto)
 
-  +------------------+                          +------------------+
-  |    Provider      |----- owns and publishes ->|  Schema document |
-  |   (Service B)    |     OpenAPI YAML,           |  single source   |
-  |                  |      .proto file            |   of truth       |
-  +------------------+                          +---------+--------+
-                                                            |
-                                    +-----------------------+------------------------+
-                                    |                                                |
-                                    v                                                v
-                          +------------------+                            +------------------+
-                          |  Provider test,  |                            |  Consumer test,  |
-                          |  own responses    |                            |  own requests     |
-                          |  validated against|                            |  validated against|
-                          |  the schema        |                            |  the schema        |
-                          +------------------+                            +------------------+
++----------------------+
+| Provider (Service B) |
++----------------------+
+           | owns and publishes OpenAPI YAML, .proto file
+           v
++-----------------------------------------+
+| Schema document, single source of truth |
++-----------------------------------------+
+           |
+     +-----+-----+
+     |           |
++------------------------+  +------------------------+
+| Provider test,         |  | Consumer test,         |
+| own responses validated|  | own requests validated |
+| against the schema     |  | against the schema     |
++------------------------+  +------------------------+
 ```
 
 ## 7. Dynamics

--- a/patterns/24-stream-processing/README.md
+++ b/patterns/24-stream-processing/README.md
@@ -2,7 +2,7 @@
 
 Origin. Dataflow model, Kafka documentation
 
-7 entries, 41,971 words, 1 more planned, 8 total when the family is complete. Every entry carries all 18
+7 entries, 41,961 words, 1 more planned, 8 total when the family is complete. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Stream Processing
@@ -15,7 +15,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Replayable Log](replayable-log.md) | canonical | 4,185 | A traditional message queue removes a message once it has been consumed. |
 | [Stream Backpressure](stream-backpressure.md) | established | 4,619 | In a single-process reactive pipeline the backpressure problem is a pair, one producer and one consumer, and a demand-signaling or buffer-based protocol between the two is ... |
 | [Stream-Table Duality](stream-table-duality.md) | established | 5,645 | Kafka's own documentation frames the problem as a first-class support gap a stream-processing technology must close, not a hypothetical. |
-| [Watermark](watermark.md) | established | 9,884 | A stream processing system that groups records by when they actually happened, not by when the system happened to receive them, faces a specific unanswerable-looking question. |
+| [Watermark](watermark.md) | established | 9,874 | A stream processing system that groups records by when they actually happened, not by when the system happened to receive them, faces a specific unanswerable-looking question. |
 
 ## Planned
 

--- a/patterns/24-stream-processing/watermark.md
+++ b/patterns/24-stream-processing/watermark.md
@@ -82,59 +82,65 @@ Kafka Streams' structurally different substitute. There is no propagated waterma
 ## 6. ASCII structure diagram
 
 ```
-  partitioned source (N partitions, e.g. a Kafka topic)
-        |
-        v
-  per-partition watermark generator      (periodic: onEvent() + onPeriodicEmit()
-        |  (one per partition,            punctuated: fires on an in-band marker event)
-        |   independent of the others)
-        v
-  per-partition watermarks merged inside the source operator
-  (same min-of-inputs rule as the operator merge below, applied one level earlier)
-        |
-        v
-  source operator's emitted watermark  ---->  [optional: idle-source exclusion]
-        |                                     [optional: watermark alignment,
-        |                                      pauses a source that drifts too
-        |                                      far ahead of its alignment group]
-        v
-  downstream operator A  <---(input 1)---  source operator's watermark
-        ^
-        |
-  downstream operator A  <---(input 2)---  a different upstream operator's watermark
-        |
-        v
-  operator A's watermark = min( operator A's own oldest unfinished work,
-                                 watermark of every upstream input to A )
-        |
-        | whenever an operator's own event time advances, it emits a
-        | new watermark downstream to its successor operators
-        v
-  ... the same merge rule repeats recursively through the DAG ...
-        |
-        v
-  per-key timers fire, in increasing timestamp order, as the low
-  watermark passes each timer's scheduled value
-        |
-        v
-  a window's trigger fires once the watermark crosses the window's
-  event-time end (the handoff into windowing and triggering, see
-  the related event-time-processing entry)
-        |
-        v
-  a late record arrives, event time earlier than the current watermark
-        |
-        +--- within the allowed lateness or grace period --> re-enters
-        |                                                     the window, re-fires the trigger
-        |
-        +--- past that horizon -----------------------------> dropped, or
-                                                                routed to a side output if configured
+partitioned source (N partitions, e.g. a Kafka topic)
+  |
+  v
+per-partition watermark generator
+  (one per partition, independent of the others)
+  (periodic: onEvent() + onPeriodicEmit())
+  (punctuated: fires on an in-band marker event)
+  |
+  v
+per-partition watermarks merged inside the source operator
+  (same min-of-inputs rule as the operator merge below,)
+  (applied one level earlier)
+  |
+  v
+source operator's emitted watermark
+  (optional: idle-source exclusion)
+  (optional: watermark alignment, pauses a source that)
+  (drifts too far ahead of its alignment group)
+  |
+  v
+downstream operator A
+  (input 1, from the source operator's watermark)
+  (input 2, from a different upstream operator's watermark)
+  |
+  v
+operator A's watermark = min(
+  operator A's own oldest unfinished work,
+  watermark of every upstream input to A )
+  |
+  (whenever an operator's own event time advances, it)
+  (emits a new watermark downstream to its successors)
+  v
+... the same merge rule repeats recursively through the DAG ...
+  |
+  v
+per-key timers fire, in increasing timestamp order, as the low
+watermark passes each timer's scheduled value
+  |
+  v
+a window's trigger fires once the watermark crosses the
+window's event-time end
+  (the handoff into windowing and triggering, see the)
+  (related event-time-processing entry)
+  |
+  v
+a late record arrives, event time earlier than the watermark
+  |
+  +-- within the allowed lateness or grace period
+  |     --> re-enters the window, re-fires the trigger
+  |
+  +-- past that horizon
+        --> dropped, or routed to a side output if configured
 
-  [ separate, optional path, MillWheel-specific: a sharded, central
-    watermark authority aggregates every worker's already-computed
-    minimum, purely to report progress and to compute percentile
-    (heuristic, approximate) watermarks. It never leads what the
-    workers themselves have already computed. ]
+[ separate, optional path, MillWheel-specific: a sharded,
+  central watermark authority aggregates every worker's
+  already-computed minimum, purely to report progress and
+  to compute percentile (heuristic, approximate)
+  watermarks. It never leads what the workers themselves
+  have already computed. ]
 ```
 
 The per-partition merge and the per-operator merge are the same rule applied at two structural levels, not two different mechanisms. Flink's own documentation states the per-partition case is merged "in the same way as watermarks are merged on stream shuffles," the identical min-of-inputs rule that governs every later step in the chain.


### PR DESCRIPTION
## Summary

Continues the diagram-width review pass from the previous PR (#424). This batch covers the eleven widest remaining offenders, 98 to 115 characters, plus the single widest entry in the whole catalogue, marker-interface.md at 115 characters, which was read but inadvertently not redrawn in the first batch.

- marker-interface.md, 115 to 48 characters
- open-closed-principle.md, 102 to 71 characters
- watermark.md, 101 to 63 characters
- event-message.md, 101 to 71 characters
- document-message.md, 101 to 65 characters
- mapper.md, 101 to 60 characters
- two-step-view.md, 100 to 50 characters
- conway-law.md, 100 to 59 characters
- gossip-protocol.md, 99 to 60 characters
- etl.md, 99 to 54 characters
- contract-test.md, 98 to 61 characters

Every redrawn diagram preserves 100% of the original semantic content, every box's fields, every prose annotation, every before/after framing. Wide multi-column layouts (a 3-way fan-out, a 2x2 organization/system graph) became either a narrower vertical stack or a compact shared-width column row, whichever kept the relationships clearest under 78 characters.

## Gates

- check-structure.py, 884/884
- check-prose.py, 925/925
- markdownlint-cli2 v0.23.2, 0 issues
- validate-refs.py --strict, every citation still resolves
- check-code.py --strict, 2826 code blocks compiled, 0 failed
- gen-indexes.py re-run after the edits, regenerating the seven family README tables these eleven entries span, the same discipline the previous PR's fix commit established for a byte-count-changing content edit

No structural, prose, reference, or code content changed anywhere in this PR, only the diagram fences.

117 more entries with the same width issue remain, worked through in following batches.