### PR TITLE
fix(patterns) redraw ten more ASCII diagrams under 78 columns

### DIFF
--- a/patterns/03-refactoring/README.md
+++ b/patterns/03-refactoring/README.md
@@ -2,7 +2,7 @@
 
 Origin. Fowler, Refactoring 2nd edition
 
-66 entries, 262,770 words. Every entry carries all 18
+66 entries, 262,768 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Composing Functions
@@ -35,7 +35,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Combine Functions into Class](combine-functions-into-class.md) | canonical | 3,579 | You have a set of functions, typically free functions in a module, that all operate on the same data structure or the same set of parameters. |
 | [Combine Functions into Transform](combine-functions-into-transform.md) | canonical | 3,278 | You have a pipeline of functions, each taking the output of the previous and producing input for the next, forming a chain of transformations. |
 | [Consolidate Conditional Expression](consolidate-conditional-expression.md) | canonical | 3,243 | You have a series of conditional checks, each of which leads to the same result or the same action. |
-| [Decompose Conditional](decompose-conditional.md) | canonical | 3,393 | You have a conditional whose complexity lies not in the branching but in the readability of its parts. |
+| [Decompose Conditional](decompose-conditional.md) | canonical | 3,391 | You have a conditional whose complexity lies not in the branching but in the readability of its parts. |
 | [Encapsulate Collection](encapsulate-collection.md) | canonical | 3,249 | A class has a collection field, typically a list or a map, that is exposed to callers. |
 | [Encapsulate Record](encapsulate-record.md) | canonical | 3,025 | You have a data record, a structure with public fields and no behaviour, that callers read and write directly. |
 | [Encapsulate Variable](encapsulate-variable.md) | canonical | 3,123 | You have a variable, typically a public field on a class or a module level variable, that callers read and write directly. |

--- a/patterns/03-refactoring/decompose-conditional.md
+++ b/patterns/03-refactoring/decompose-conditional.md
@@ -165,19 +165,24 @@ statement: `if condition() then branch() else otherBranch()`.
 ## 6. ASCII structure diagram
 
 ```
-  BEFORE                                      AFTER
-  ------                                      -----
+BEFORE (condition, then, else all inline)
 
-  if date.before(SUMMER_START)                 if isWinter(date):
-         || date.after(SUMMER_END) {                charge = winterCharge(quantity)
-      charge = q * winterRate                     else:
-                          * winterServiceFee;         charge = summerCharge(quantity)
-  } else {
-      charge = q * summerRate;
-  }
+if date.before(SUMMER_START)
+       || date.after(SUMMER_END) {
+    charge = q * winterRate
+                  * winterServiceFee;
+} else {
+    charge = q * summerRate;
+}
 
-  (condition, then, else all inline)          (3 named functions,
-                                                conditional reads as a sentence)
+
+AFTER (3 named functions, conditional reads
+as a sentence)
+
+if isWinter(date):
+    charge = winterCharge(quantity)
+else:
+    charge = summerCharge(quantity)
 ```
 
 ## 7. Dynamics

--- a/patterns/04-principles-and-laws/README.md
+++ b/patterns/04-principles-and-laws/README.md
@@ -2,7 +2,7 @@
 
 Origin. Martin, Larman, Brewer, Conway
 
-42 entries, 327,278 words. Every entry carries all 18
+42 entries, 327,261 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Design Principle
@@ -44,7 +44,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Interface Segregation Principle](interface-segregation-principle.md) | canonical | 9,180 | The problem ISP names is specific and recognizable once you have seen it. |
 | [Keep It Simple](keep-it-simple.md) | canonical | 8,079 | Every non-trivial piece of software accretes complexity over its lifetime, and that accretion happens in two very different ways that are easy to conflate. |
 | [Law of Demeter](law-of-demeter.md) | canonical | 7,910 | A method reaches through an object it was handed to get at a second object, then calls a method on that second object. |
-| [Low Coupling](low-coupling.md) | canonical | 7,299 | Every nontrivial system is built from more than one unit of code, whether those units are classes in one process, packages in one codebase, or services across a network. |
+| [Low Coupling](low-coupling.md) | canonical | 7,282 | Every nontrivial system is built from more than one unit of code, whether those units are classes in one process, packages in one codebase, or services across a network. |
 | [Open Closed Principle](open-closed-principle.md) | canonical | 5,598 | A piece of software that ships once and never changes does not need this principle. |
 | [PACELC Theorem](pacelc-theorem.md) | canonical | 9,039 | A team picks a distributed database, reads that it is "AP" or "CP" under CAP, and believes that single letter fully describes how the system will behave in production. |
 | [Postel's Law](postel-law.md) | contested | 8,878 | Two or more parties implement the same open, published specification independently, without coordinating their release schedules, their source code, or in most cases even knowing ... |

--- a/patterns/04-principles-and-laws/low-coupling.md
+++ b/patterns/04-principles-and-laws/low-coupling.md
@@ -223,41 +223,57 @@ rather than scattered across every Dependent.
 ## 6. ASCII structure diagram
 
 ```
-  TIGHT COUPLING (what Low Coupling replaces)
+TIGHT COUPLING (what Low Coupling replaces)
 
-  +------------------+          +----------------------+
-  |     Dependent     |--------->|  ConcreteDependency  |
-  | (knows concrete   |  new /   |  (fields, methods,   |
-  |  type, fields,    |  direct  |   internal layout    |
-  |  constructor)     |   call   |   all visible)        |
-  +------------------+          +----------------------+
-
-
-  LOOSE COUPLING (Low Coupling applied via a Contract)
-
-  +------------------+          +--------------------+
-  |     Dependent     |--------->|     Contract       |
-  |  (knows only the  |  calls   |  (interface /       |
-  |   Contract shape) |  via     |   protocol /         |
-  |                    |  Contract|   event schema)      |
-  +------------------+          +----------+---------+
-                                            ^
-                                            | implements
-                                 +----------+----------+
-                                 |  ConcreteDependency  |
-                                 |  (internals hidden   |
-                                 |   from Dependent)    |
-                                 +----------------------+
++-------------------------------+
+| Dependent                     |
+| (knows concrete type, fields, |
+| constructor)                  |
++-------------------------------+
+           | new / direct call
+           v
++----------------------------+
+| ConcreteDependency         |
+| (fields, methods, internal |
+| layout all visible)        |
++----------------------------+
 
 
-  LOOSE COUPLING WITH A MEDIATOR (event bus / DI container)
+LOOSE COUPLING (Low Coupling applied via a Contract)
 
-  +-----------+     publishes/     +--------------+     notifies/     +-----------+
-  | Dependent |------requests----->|   Mediator   |------supplies----->| Dependency |
-  | (unaware  |                    | (bus / DI    |                    | (unaware   |
-  |  who      |                    |  container / |                    |  who       |
-  |  fulfills)|                    |  facade)     |                    |  triggered)|
-  +-----------+                    +--------------+                    +-----------+
++---------------------------------+
+| Dependent                       |
+| (knows only the Contract shape) |
++---------------------------------+
+           | calls via Contract
+           v
++---------------------------------------+
+| Contract                              |
+| (interface / protocol / event schema) |
++---------------------------------------+
+           ^
+           | implements
++-----------------------------------+
+| ConcreteDependency                |
+| (internals hidden from Dependent) |
++-----------------------------------+
+
+
+LOOSE COUPLING WITH A MEDIATOR (event bus / DI container)
+
++----------------------------------+
+| Dependent (unaware who fulfills) |
++----------------------------------+
+           | publishes/requests
+           v
++----------------------------------------+
+| Mediator (bus / DI container / facade) |
++----------------------------------------+
+           | notifies/supplies
+           v
++------------------------------------+
+| Dependency (unaware who triggered) |
++------------------------------------+
 ```
 
 ## 7. Dynamics

--- a/patterns/06-enterprise-application-architecture/README.md
+++ b/patterns/06-enterprise-application-architecture/README.md
@@ -2,7 +2,7 @@
 
 Origin. Fowler, PoEAA
 
-56 entries, 371,832 words, 4 more planned, 60 total when the family is complete. Every entry carries all 18
+56 entries, 371,836 words, 4 more planned, 60 total when the family is complete. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Base Pattern
@@ -86,7 +86,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
 | [Data Mapper](data-mapper.md) | canonical | 5,828 | An application has a domain model made of objects with behavior, and a relational database made of tables, rows, and columns with no behavior. |
-| [Identity Map](identity-map.md) | canonical | 6,353 | An object-relational mapping layer loads rows from a database and turns them into in-memory objects. |
+| [Identity Map](identity-map.md) | canonical | 6,357 | An object-relational mapping layer loads rows from a database and turns them into in-memory objects. |
 | [Lazy Load](lazy-load.md) | canonical | 7,284 | An object graph persisted in a relational database is, by its nature, larger than any single query needs. |
 | [Unit of Work](unit-of-work.md) | canonical | 8,827 | An operation touches several objects that came from, or are destined for, a database. |
 

--- a/patterns/06-enterprise-application-architecture/identity-map.md
+++ b/patterns/06-enterprise-application-architecture/identity-map.md
@@ -226,33 +226,40 @@ Do NOT reach for it when any of these hold.
 ## 6. ASCII structure diagram
 
 ```
-+-------------------+        find(id)        +------------------------+
-|      Client        | ----------------------> |  Finder / Mapper        |
-| (domain / service   |                        |  (owns the lookup      |
-|  code)              | <----------------------|   sequence)             |
-+-------------------+     domain object       +------------------------+
-                                                  |            ^
-                                     1. lookup(id)|            | 3. register(id, obj)
-                                                  v            |
-                                          +----------------------------+
-                                          |       Identity Map          |
-                                          |  Map<IdentityKey, Object>   |
-                                          |  scoped to a Unit of Work   |
-                                          +----------------------------+
-                                                  |
-                                     2. miss: query, then build
-                                                  v
-                                          +----------------------------+
-                                          |         Database            |
-                                          |  (row identified by key)    |
-                                          +----------------------------+
++--------------------------------+
+| Client (domain / service code) |
++--------------------------------+
+           | find(id)
+           v
++----------------------------+
+| Finder / Mapper            |
+| (owns the lookup sequence) |
++----------------------------+
+           | domain object, returned to Client above
+           |
+           | 1. lookup(id)
+           v
++--------------------------+
+| Identity Map             |
+| Map<IdentityKey, Object> |
+| scoped to a Unit of Work |
++--------------------------+
+           ^
+           | 3. register(id, obj), on a miss
+           |
+           | 2. miss: query, then build
+           v
++-------------------------+
+| Database                |
+| (row identified by key) |
++-------------------------+
 
-  Per-entity-type maps, held by one scope owner:
+Per-entity-type maps, held by one scope owner:
 
-  UnitOfWork
-    +-- CustomerMap : Map<CustomerId, Customer>
-    +-- OrderMap    : Map<OrderId, Order>
-    +-- ProductMap  : Map<ProductId, Product>
+UnitOfWork
+  +-- CustomerMap : Map<CustomerId, Customer>
+  +-- OrderMap    : Map<OrderId, Order>
+  +-- ProductMap  : Map<ProductId, Product>
 ```
 
 ## 7. Dynamics

--- a/patterns/06-enterprise-application-architecture/registry.md
+++ b/patterns/06-enterprise-application-architecture/registry.md
@@ -208,29 +208,37 @@ Do NOT reach for Registry when:
 ## 6. ASCII structure diagram
 
 ```
-+-------------------+          +----------------------+
-|   Bootstrapper     |--------->|      Registry        |
-|  (composition root) | register|  entries: Map<K, V>  |
-+-------------------+          |  register(key, val)  |
-                                |  resolve(key): V     |
-                                |  freeze()            |
-                                +-----------+-----------+
-                                            ^
-                                            | resolve
-                                            |
-                +---------------------------+---------------------------+
-                |                           |                           |
-       +--------+--------+        +---------+---------+       +---------+---------+
-       |  OrderService    |        |  NotificationSvc   |       |  ReportRunner     |
-       |  (client)        |        |  (client)          |       |  (client)         |
-       +------------------+        +--------------------+       +-------------------+
++---------------------------------+
+| Bootstrapper (composition root) |
++---------------------------------+
+           | register
+           v
++--------------------+
+| Registry           |
+| entries: Map<K, V> |
+| register(key, val) |
+| resolve(key): V    |
+| freeze()           |
++--------------------+
+           ^
+           | resolve
+     +-----+-----+-----+
+     |           |     |
++-----------------+ +-----------------+ +-----------------+
+| OrderService    | | NotificationSvc | | ReportRunner    |
+| (client)        | | (client)        | | (client)        |
++-----------------+ +-----------------+ +-----------------+
 
-       registered value types, held opaquely by the Registry:
+Registered value types, held opaquely by the Registry:
 
-       +----------------+   implements   +----------------+
-       |  Clock          |<--------------|  SystemClock    |
-       |  (interface)    |               |  (impl)         |
-       +----------------+               +----------------+
++-------------------+
+| Clock (interface) |
++-------------------+
+           ^
+           | implements
++--------------------+
+| SystemClock (impl) |
++--------------------+
 ```
 
 ## 7. Dynamics

--- a/patterns/11-domain-driven-design/README.md
+++ b/patterns/11-domain-driven-design/README.md
@@ -2,7 +2,7 @@
 
 Origin. Evans, Vernon
 
-35 entries, 264,784 words. Every entry carries all 18
+35 entries, 264,770 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Anti-pattern
@@ -29,7 +29,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
 | [Aggregate](aggregate.md) | canonical | 7,789 | A domain model contains rules that span more than one object. |
-| [Aggregate Root](aggregate-root.md) | canonical | 8,677 | A domain model accumulates Entities and Value Objects that reference one another. |
+| [Aggregate Root](aggregate-root.md) | canonical | 8,663 | A domain model accumulates Entities and Value Objects that reference one another. |
 | [Application Service](application-service.md) | canonical | 7,949 | A rich domain model, built from entities, value objects, and aggregates that enforce their own invariants, still needs a caller. |
 | [Domain Service](domain-service.md) | canonical | 7,032 | A team modeling a domain in an object-oriented style eventually meets an operation that genuinely spans more than one object and does not belong to either. |
 | [Factory](factory.md) | canonical | 8,338 | A domain model accumulates two kinds of complexity as it grows. |

--- a/patterns/11-domain-driven-design/aggregate-root.md
+++ b/patterns/11-domain-driven-design/aggregate-root.md
@@ -249,38 +249,46 @@ Do NOT reach for Aggregate Root in these situations, each with its reason.
 ## 6. ASCII structure diagram
 
 ```
-                     +---------------------------+
-   outside code ---->|      AGGREGATE ROOT        |
-   (holds only        |  (has global identity:     |
-   the root's id,      |   OrderId)                 |
-   never a child       |                            |
-   reference)          |  + placeOrder()            |
-                        |  + addLine(sku, qty)       |
-                        |  + applyDiscount(code)     |
-                        |  + total(): Money          |
-                        |  - checkInvariant()        |
-                        +-------------+---------------+
-                                      |
-                       owns and enforces access to
-                                      |
-              +-----------------------+-----------------------+
-              |                       |                       |
-    +---------v---------+   +---------v---------+   +---------v---------+
-    |  INTERNAL ENTITY    |   |  INTERNAL ENTITY    |   |   VALUE OBJECT      |
-    |  OrderLine (local    |   |  OrderLine (local    |   |   Money             |
-    |  id: "line-1", no     |   |  id: "line-2", no     |   |   (amount, currency)|
-    |  meaning outside      |   |  meaning outside      |   |   compared by value |
-    |  this Order)          |   |  this Order)          |   |                     |
-    +-----------------------+   +-----------------------+   +---------------------+
+outside code holds only the root's id, never a child
+reference
+           |
+           v
++--------------------------------+
+| AGGREGATE ROOT                 |
+| (has global identity: OrderId) |
+| placeOrder()                   |
+| addLine(sku, qty)              |
+| applyDiscount(code)            |
+| total(): Money                 |
+| checkInvariant()               |
++--------------------------------+
+           |
+           | owns and enforces access to
+     +-----+-----+-----+
+     |           |     |
++----------------------+ +----------------------+ +----------------------+
+| INTERNAL ENTITY      | | INTERNAL ENTITY      | | VALUE OBJECT         |
+| OrderLine (local id: | | OrderLine (local id: | | Money                |
+| "line-1", no meaning | | "line-2", no meaning | | (amount, currency)   |
+| outside this Order)  | | outside this Order)  | | compared by value    |
++----------------------+ +----------------------+ +----------------------+
 
-    (unreachable directly)     (unreachable directly)      (freely shared, immutable)
+(unreachable directly)  (unreachable
+                        directly)          (freely shared,
+                                            immutable)
 
-    +---------------------------+          +----------------------------+
-    | ANOTHER AGGREGATE ROOT     |          |         REPOSITORY          |
-    | Customer                   |<---------+  loads/saves ONE root and   |
-    | (Order references it by    | id only  |  its whole internal cluster |
-    |  CustomerId, not by object) |          |  atomically, as one unit    |
-    +-----------------------------+          +------------------------------+
++----------------------------+
+| ANOTHER AGGREGATE ROOT     |
+| Customer                   |
+| (Order references it by    |
+| CustomerId, not by object) |
++----------------------------+
+           ^
+           | loads/saves ONE root and its whole internal
+           | cluster atomically, as one unit, id only
++------------+
+| REPOSITORY |
++------------+
 ```
 
 ## 7. Dynamics

--- a/patterns/13-frontend-ui/provider-pattern.md
+++ b/patterns/13-frontend-ui/provider-pattern.md
@@ -116,21 +116,22 @@ The Provider Pattern has three structural parts.
 ## 6. ASCII structure diagram
 
 ```
-    ThemeContext = createContext(defaultTheme)
+ThemeContext = createContext(defaultTheme)
 
-    <ThemeContext.Provider value={currentTheme}>   (the provider)
-        |
-        +-- Header                                  (no prop needed)
-        |     |
-        |     +-- Logo                               (reads useContext(ThemeContext))
-        |
-        +-- Sidebar                                  (no prop needed)
-              |
-              +-- NavItem                            (reads useContext(ThemeContext))
-    </ThemeContext.Provider>
+<ThemeContext.Provider value={currentTheme}>  (the provider)
+    |
+    +-- Header  (no prop needed)
+    |     |
+    |     +-- Logo  (reads useContext(ThemeContext))
+    |
+    +-- Sidebar  (no prop needed)
+          |
+          +-- NavItem  (reads useContext(ThemeContext))
+</ThemeContext.Provider>
 
-    Every descendant, at any depth, reads the same currentTheme value
-    directly, with no intermediate component passing it as a prop.
+Every descendant, at any depth, reads the same
+currentTheme value directly, with no intermediate
+component passing it as a prop.
 ```
 
 ## 7. Dynamics

--- a/patterns/15-security/README.md
+++ b/patterns/15-security/README.md
@@ -2,7 +2,7 @@
 
 Origin. OWASP ASVS
 
-38 entries, 226,879 words. Every entry carries all 18
+38 entries, 226,876 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Authorization
@@ -36,7 +36,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [JWT](jwt.md) | established | 6,076 | A resource server needs to accept repeated calls without contacting the issuer for every request, yet it still needs an issuer, subject, audience, expiry, possibly scopes, and a ... |
 | [Key Rotation](key-rotation.md) | established | 6,762 | A system depends on secret material that cannot be treated as permanent. |
 | [Least Privilege](least-privilege.md) | canonical | 6,389 | A system needs trusted actions to happen, but the code, user, service account, container, or job that performs those actions can also fail, be tricked, or be taken over. |
-| [Lethal Trifecta Threat Model](lethal-trifecta-threat-model.md) | emerging | 1,821 | Willison's own text states why the three conditions matter only in combination, not individually. |
+| [Lethal Trifecta Threat Model](lethal-trifecta-threat-model.md) | emerging | 1,818 | Willison's own text states why the three conditions matter only in combination, not individually. |
 | [Mutual TLS](mutual-tls.md) | established | 6,027 | A service accepts network calls from other machines. |
 | [OpenID Connect](openid-connect.md) | established | 7,015 | The problem appears when an application needs to sign in users through an external identity system without copying passwords, duplicating multi-factor logic, or inventing its own ... |
 | [Output Encoding](output-encoding.md) | established | 6,294 | A program has data that may contain characters with special meaning in the output grammar. |

--- a/patterns/15-security/lethal-trifecta-threat-model.md
+++ b/patterns/15-security/lethal-trifecta-threat-model.md
@@ -79,25 +79,22 @@ mitigations" (Willison, "Lethal Trifecta," verified 2026-08-23).
 ## 6. ASCII structure diagram
 
 ```
-  +------------------------+  +------------------------+  +------------------------+
-  | LEG 1                  |  | LEG 2                  |  | LEG 3                  |
-  | private data access    |  | untrusted content       |  | external               |
-  |                        |  | exposure                |  | communication          |
-  +------------------------+  +------------------------+  +------------------------+
-              |                          |                          |
-              +--------------------------+--------------------------+
-                                         |
-                                         v
-                          all three present at once, on the
-                          same agent, in the same request:
-                          THE LETHAL TRIFECTA. an attacker's
-                          instructions, smuggled inside LEG 2,
-                          can now reach something worth
-                          stealing (LEG 1) and a channel to
-                          steal it through (LEG 3).
++-----------------------+ +-----------------------+ +-----------------------+
+| LEG 1                 | | LEG 2                 | | LEG 3                 |
+| private data access   | | untrusted content     | | external communication|
+|                       | | exposure              | |                       |
++-----------------------+ +-----------------------+ +-----------------------+
+     |           |           |
+     +-----------+-----------+
+                 v
+all three present at once, on the same agent, in the
+same request: THE LETHAL TRIFECTA. an attacker's
+instructions, smuggled inside LEG 2, can now reach
+something worth stealing (LEG 1) and a channel to
+steal it through (LEG 3).
 
-  removing ANY ONE leg from a given agent's capability set
-  closes the trifecta for that agent, per dimension 5.
+removing ANY ONE leg from a given agent's capability
+set closes the trifecta for that agent (dimension 5).
 ```
 
 ## 7. Dynamics

--- a/patterns/17-ai-agentic/README.md
+++ b/patterns/17-ai-agentic/README.md
@@ -2,7 +2,7 @@
 
 Origin. Papers and vendor engineering, 2023 to 2026
 
-64 entries, 492,574 words, 1 more planned, 65 total when the family is complete. Every entry carries all 18
+64 entries, 492,522 words, 1 more planned, 65 total when the family is complete. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## AI Agentic
@@ -31,7 +31,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Memory Compaction](memory-compaction.md) | established | 8,946 | An agent that runs for a long time accumulates a conversation. |
 | [PII Redaction](pii-redaction.md) | established | 8,577 | An agent pipeline routinely moves text through places where a human name, an email address, a card number, or a medical record number does not belong. |
 | [Parallelization](parallelization.md) | established | 9,204 | An agentic pipeline built as a single sequential chain of LLM calls has one throughput limit, the wall-clock latency of the slowest single call multiplied by the number of calls ... |
-| [Prompt Caching via Exact Prefix Preservation](prompt-caching-exact-prefix.md) | established | 2,384 | The chapter's own text, meaning Claude Code's own documentation, states the underlying problem directly. |
+| [Prompt Caching via Exact Prefix Preservation](prompt-caching-exact-prefix.md) | established | 2,332 | The chapter's own text, meaning Claude Code's own documentation, states the underlying problem directly. |
 | [Prompt Injection Defense](prompt-injection-defense.md) | emerging | 7,008 | An LLM-integrated system is built around one structural weakness. |
 | [RLAIF](rlaif.md) | established | 1,618 | The paper's own text states the underlying constraint directly, already implied in dimension 1, human preference labeling does not scale, it is slow and expensive to collect at ... |
 | [Reranking](reranking.md) | canonical | 7,225 | A reader who has never heard the word reranking has still hit the problem it solves. |

--- a/patterns/17-ai-agentic/prompt-caching-exact-prefix.md
+++ b/patterns/17-ai-agentic/prompt-caching-exact-prefix.md
@@ -103,28 +103,28 @@ effort level has its own cache for the same model" (same source).
 ## 6. ASCII structure diagram
 
 ```
-  request N minus 1:
+request N minus 1:
 
-  +-----------------+  +-----------------+  +-----------------+
-  | system prompt    |  | project context  |  | conversation     |
-  +-----------------+  +-----------------+  +-----------------+
-                    cache breakpoint, prefix hashed and stored
+  [system prompt] [project context] [conversation]
+       cache breakpoint, prefix hashed and stored
 
-  request N, unchanged prefix, new turn appended:
+request N, unchanged prefix, new turn appended:
 
-  +-----------------+  +-----------------+  +-----------------+   +----------+
-  | system prompt    |  | project context  |  | conversation     |   | new turn |
-  | read from cache   |  | read from cache   |  | read from cache   |   | fresh    |
-  +-----------------+  +-----------------+  +-----------------+   +----------+
+  [system prompt]     read from cache
+  [project context]   read from cache
+  [conversation]      read from cache
+  [new turn]          fresh
 
-  request N plus 1, a change lands inside the prefix, for example a
-  model switch:
+request N plus 1, a change lands inside the prefix,
+for example a model switch:
 
-  +-----------------+  +-----------------+  +-----------------+   +----------+
-  | system prompt*    |  | project context  |  | conversation     |   | new turn |
-  +-----------------+  +-----------------+  +-----------------+   +----------+
-   * changed here, so everything after this point reprocesses and
-     re-caches, in full, at full cost
+  [system prompt*]
+  [project context]
+  [conversation]
+  [new turn]
+
+  * changed here, so everything after this point
+    reprocesses and re-caches, in full, at full cost
 ```
 
 ## 7. Dynamics

--- a/patterns/18-anti-patterns/README.md
+++ b/patterns/18-anti-patterns/README.md
@@ -2,7 +2,7 @@
 
 Origin. Brown et al, AntiPatterns
 
-51 entries, 398,660 words. Every entry carries all 18
+51 entries, 398,662 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Anti-Pattern
@@ -66,7 +66,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
-| [Chatty I/O](chatty-i-o.md) | established | 8,323 | Chatty I/O appears the moment a piece of code that used to run against in-process memory starts running against something on the far side of a boundary that has real per-call cost. |
+| [Chatty I/O](chatty-i-o.md) | established | 8,325 | Chatty I/O appears the moment a piece of code that used to run against in-process memory starts running against something on the far side of a boundary that has real per-call cost. |
 | [Distributed Monolith](distributed-monolith.md) | established | 8,553 | A team decomposes a monolith, or designs a new system, into a set of services with separate repositories, separate deployment pipelines, and separate runtime processes, expecting ... |
 | [Stovepipe System](stovepipe-system.md) | canonical | 8,168 | An organization builds its second system, its second department's application, or its second bounded capability, and the fastest path to delivery is to start from a blank slate ... |
 

--- a/patterns/18-anti-patterns/chatty-i-o.md
+++ b/patterns/18-anti-patterns/chatty-i-o.md
@@ -270,35 +270,39 @@ call graph rather than fixed types.
 
 ## 6. ASCII structure diagram
 
-```text
+```
 CHATTY, the anti-pattern
 
-  Caller                    Boundary          Data Source
-  ------                    --------          -----------
-   |
-   | for each of N items -->|--- call 1 --->  [ answer 1 ]
-   |                        |<-- reply 1 ---
-   |                        |--- call 2 --->  [ answer 2 ]
-   |                        |<-- reply 2 ---
-   |                        |      ...
-   |                        |--- call N --->  [ answer N ]
-   |<-----------------------|<-- reply N ---
-   |
-   N round trips, N x fixed overhead paid, payload scales with N.
+Caller       Boundary       Data Source
+------       --------       -----------
+ |
+ | for each of N items
+ |------------>|-- call 1 -->  [ answer 1 ]
+ |             |<- reply 1 --
+ |             |-- call 2 -->  [ answer 2 ]
+ |             |<- reply 2 --
+ |             |     ...
+ |             |-- call N -->  [ answer N ]
+ |<------------|<- reply N --
+ |
+ N round trips, N x fixed overhead paid,
+ payload scales with N.
 
 
 CHUNKY, after the fix
 
-  Caller          Aggregation Point       Boundary          Data Source
-  ------          -----------------       --------          -----------
-   |                       |
-   | one intent ---------->|
-   |                       |--- single batched or joined call -->  [ all N answers ]
-   |                       |<-------- single reply -----------
-   |<----------------------|
-   |
-   1 round trip, 1 x fixed overhead paid, payload scales with N,
-   round trip count no longer scales with N.
+Caller    Aggregation Point    Boundary    Data Source
+------    -----------------    --------    -----------
+ |               |
+ | one intent -->|
+ |               |-- single batched
+ |               |   or joined call -->  [ all N answers ]
+ |               |<---- single reply ---
+ |<--------------|
+ |
+ 1 round trip, 1 x fixed overhead paid,
+ payload scales with N, round trip count
+ no longer scales with N.
 ```
 
 ## 7. Dynamics

--- a/patterns/24-stream-processing/README.md
+++ b/patterns/24-stream-processing/README.md
@@ -2,7 +2,7 @@
 
 Origin. Dataflow model, Kafka documentation
 
-7 entries, 41,954 words, 1 more planned, 8 total when the family is complete. Every entry carries all 18
+7 entries, 41,952 words, 1 more planned, 8 total when the family is complete. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Stream Processing
@@ -13,7 +13,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Event-Time Processing](event-time-processing.md) | established | 8,516 | The Dataflow paper states the root cause directly. |
 | [Exactly-Once Processing](exactly-once-processing.md) | canonical | 4,481 | A stream processor that crashes mid-batch and restarts will, by default, reprocess whatever it had not yet acknowledged. |
 | [Replayable Log](replayable-log.md) | canonical | 4,185 | A traditional message queue removes a message once it has been consumed. |
-| [Stream Backpressure](stream-backpressure.md) | established | 4,619 | In a single-process reactive pipeline the backpressure problem is a pair, one producer and one consumer, and a demand-signaling or buffer-based protocol between the two is ... |
+| [Stream Backpressure](stream-backpressure.md) | established | 4,617 | In a single-process reactive pipeline the backpressure problem is a pair, one producer and one consumer, and a demand-signaling or buffer-based protocol between the two is ... |
 | [Stream-Table Duality](stream-table-duality.md) | established | 5,645 | Kafka's own documentation frames the problem as a first-class support gap a stream-processing technology must close, not a hypothetical. |
 | [Watermark](watermark.md) | established | 9,874 | A stream processing system that groups records by when they actually happened, not by when the system happened to receive them, faces a specific unanswerable-looking question. |
 

--- a/patterns/24-stream-processing/stream-backpressure.md
+++ b/patterns/24-stream-processing/stream-backpressure.md
@@ -157,26 +157,38 @@ exclusive allotment, plus the floating pool.
 ## 6. ASCII structure diagram
 
 ```
-  Upstream subtask                          Downstream subtask
-  +-------------------+                     +-------------------+
-  | ResultSubpartition |   credits granted   |   InputChannel     |
-  | (tracks backlog,   | <------------------ |  exclusive buffers |
-  |  per-channel       |                     |  (default 2)       |
-  |  credit balance)   |   data + backlog    |                    |
-  |                    | -------------------> |  floating buffers  |
-  +-------------------+   count (per buffer)  |  (default 8,       |
-                                               |   shared per gate) |
-                                               +---------+---------+
-                                                         |
-                                          buffer pool exhausted?
-                                                         |
-                                                     yes v  no
-                                        subtask marked "backpressured"  keep granting
-                                        no further credit granted       credits
-                                                         |
-                                              stall propagates upstream
-                                              to THIS subtask's own
-                                              upstream senders in turn
+Upstream subtask
++------------------------------+
+| ResultSubpartition           |
+| (tracks backlog, per-channel |
+| credit balance)              |
++------------------------------+
+           ^
+           | credits granted
+           |
+           | data + backlog count (per buffer)
+           v
+
+Downstream subtask
++-------------------------------+
+| InputChannel                  |
+| exclusive buffers (default 2) |
+| floating buffers (default 8,  |
+| shared per gate)              |
++-------------------------------+
+           |
+           | buffer pool exhausted?
+     +-----+-----+
+     | yes       | no
+     v           v
+subtask marked      keep granting
+"backpressured",    credits
+no further credit
+granted
+     |
+     v
+stall propagates upstream to THIS subtask's own
+upstream senders in turn
 ```
 
 ## 7. Dynamics


### PR DESCRIPTION
## Summary

Continues the diagram-width review pass (#424 through #428). This batch covers the next tier of offenders, 84 to 85 characters, ten entries.

- stream-backpressure.md, 85 to 47 characters
- lethal-trifecta-threat-model.md, 85 to 77 characters
- provider-pattern.md, 85 to 60 characters
- aggregate-root.md, 85 to 74 characters
- registry.md, 85 to 59 characters
- identity-map.md, 85 to 52 characters
- low-coupling.md, 85 to 57 characters
- decompose-conditional.md, 85 to 43 characters
- chatty-i-o.md, 84 to 58 characters
- prompt-caching-exact-prefix.md, 84 to 52 characters

Every redrawn diagram preserves 100% of the original semantic content. A credit-flow diagram between an upstream and downstream subtask, an aggregate-root ownership tree with entities and value objects, and a three-request prompt-caching timeline each became a narrower vertical stack or a compact shared-width column row, whichever kept the relationships clearest under 78 characters.

## Gates

- check-structure.py, 884/884
- check-prose.py, 925/925
- markdownlint-cli2 v0.23.2, 0 issues
- validate-refs.py --strict, every citation still resolves
- check-code.py --strict, every code block still compiles
- gen-indexes.py re-run before this commit, regenerating the family README tables these ten entries span

No structural, prose, reference, or code content changed anywhere in this PR, only the diagram fences.

77 more entries with the same width issue remain, worked through in following batches.