### PR TITLE
fix(patterns) redraw ten more ASCII diagrams under 78 columns

### DIFF
--- a/patterns/06-enterprise-application-architecture/README.md
+++ b/patterns/06-enterprise-application-architecture/README.md
@@ -2,7 +2,7 @@
 
 Origin. Fowler, PoEAA
 
-56 entries, 371,836 words, 4 more planned, 60 total when the family is complete. Every entry carries all 18
+56 entries, 371,825 words, 4 more planned, 60 total when the family is complete. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Base Pattern
@@ -77,7 +77,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Composite Entity](composite-entity.md) | established | 1,572 | A domain model made of many small, related objects, mapped one-to-one to individually remote, individually persistent components, pays a real network and management cost for every ... |
 | [Composite View](composite-view.md) | established | 1,561 | A page is commonly built from parts that are shared across many other pages, a header, a footer, a navigation block, and duplicating those shared parts directly inside every page ... |
 | [Connection Pooling](connection-pooling.md) | canonical | 1,662 | PostgreSQL's own documentation states the direct constraint this pattern works against. |
-| [Context Object](context-object.md) | established | 1,501 | A component or a service somewhere in an application needs access to system information, such as request parameters or configuration values, that originates from a specific ... |
+| [Context Object](context-object.md) | established | 1,490 | A component or a service somewhere in an application needs access to system information, such as request parameters or configuration values, that originates from a specific ... |
 | [Tolerant Reader](tolerant-reader.md) | established | 1,517 | Fowler's own text states the underlying problem directly. |
 | [View Helper](view-helper.md) | established | 1,467 | A template-based view, such as a JSP page, is easy to fill with embedded processing logic simply because the logic and the markup live in the same file, and once that happens, the ... |
 

--- a/patterns/06-enterprise-application-architecture/context-object.md
+++ b/patterns/06-enterprise-application-architecture/context-object.md
@@ -70,14 +70,22 @@ Strategies," and "General Context Object Strategies."
 ## 6. ASCII structure diagram
 
 ```
-  +----------------------+     +----------------+     +------------------+
-  | protocol-specific       | --> | Context Object   | --> | application       |
-  | object, e.g. HTTP        |     | protocol-        |     | components and     |
-  | request                  |     | independent state |     | services            |
-  +----------------------+     +----------------+     +------------------+
++---------------------------------------------+
+| protocol-specific object, e.g. HTTP request |
++---------------------------------------------+
+           v
++----------------------------+
+| Context Object             |
+| protocol-independent state |
++----------------------------+
+           v
++-------------------------------------+
+| application components and services |
++-------------------------------------+
 
-  a component only ever reads from the context object, never the
-  protocol-specific object directly, per dimension 5
+A component only ever reads from the context object,
+never the protocol-specific object directly, per
+dimension 5.
 ```
 
 ## 7. Dynamics

--- a/patterns/06-enterprise-application-architecture/metadata-mapping.md
+++ b/patterns/06-enterprise-application-architecture/metadata-mapping.md
@@ -261,38 +261,40 @@ concerns into the domain layer.
 ## 6. ASCII structure diagram
 
 ```
-+-------------------+          reads           +--------------------+
-|   Domain Class     |<------------------------ |   Mapping Engine    |
-|   (Customer)        |    populates fields via  |  (generic, one per  |
-|                     |    reflection/accessors  |   application)      |
-+-------------------+                            +----------+---------+
-                                                              |
-                                                              | consults
-                                                              v
-                                                   +----------------------+
-                                                   |      Metadata        |
-                                                   |  class -> table      |
-                                                   |  field -> column     |
-                                                   |  assoc -> FK / join  |
-                                                   +----------+-----------+
-                                                              ^
-                                                              | parses at startup
-                                                              |
-                                                   +----------------------+
-                                                   |   Metadata Loader     |
-                                                   |  (XML / annotations / |
-                                                   |   fluent config)      |
-                                                   +----------------------+
++-------------------------------------+
+| Metadata Loader                     |
+| (XML / annotations / fluent config) |
++-------------------------------------+
+           |
+           | parses at startup
+           v
++--------------------+
+| Metadata           |
+| class -> table     |
+| field -> column    |
+| assoc -> FK / join |
++--------------------+
+           ^
+           | consults
+           |
++--------------------------------+
+| Mapping Engine                 |
+| (generic, one per application) |
++--------------------------------+
+           |
+           | reads, populates fields via
+           | reflection/accessors
+           v
++-------------------------+
+| Domain Class (Customer) |
++-------------------------+
 
-                                                   +----------------------+
-                                                   |   Relational Schema   |
-                                                   |   (tables, columns,   |
-                                                   |    FKs)               |
-                                                   +----------+-----------+
-                                                              ^
-                                                              | executes SQL against
-                                                              |
-                                                       (Mapping Engine, above)
++------------------------------------------+
+| Relational Schema (tables, columns, FKs) |
++------------------------------------------+
+
+The Mapping Engine executes SQL against the Relational
+Schema above to load and save Domain Class instances.
 ```
 
 ## 7. Dynamics

--- a/patterns/08-cloud-distributed/README.md
+++ b/patterns/08-cloud-distributed/README.md
@@ -2,7 +2,7 @@
 
 Origin. Azure Architecture Center, Nygard
 
-44 entries, 393,160 words. Every entry carries all 18
+44 entries, 393,044 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Capacity Management
@@ -24,7 +24,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
-| [External Configuration Store](external-configuration-store.md) | canonical | 8,367 | An application reads its behavior-controlling values, a database connection string, a feature toggle, a rate limit, a UI theme choice, a downstream service URL, from a file that ... |
+| [External Configuration Store](external-configuration-store.md) | canonical | 8,251 | An application reads its behavior-controlling values, a database connection string, a feature toggle, a rate limit, a UI theme choice, a downstream service URL, from a file that ... |
 
 ## Cloud and Distributed
 

--- a/patterns/08-cloud-distributed/external-configuration-store.md
+++ b/patterns/08-cloud-distributed/external-configuration-store.md
@@ -273,44 +273,40 @@ Problems and considerations, verified 2026-08-03).
 ## 6. ASCII structure diagram
 
 ```
-                        +------------------------------+
-                        |  External Configuration Store |
-                        |  (Azure App Config / AWS      |
-                        |   AppConfig / etcd / Consul /  |
-                        |   Spring Cloud Config server)  |
-                        |                                |
-                        |  key  rate.limit.checkout      |
-                        |  val  500                      |
-                        |  ver  42     label  production  |
-                        +---------------+----------------+
-                                |    ^         |    ^
-                        fetch / watch |         |    |
-                                |    | write    |    |
-              +-----------------+    +----------+    +------------------+
-              |                                                          |
-     +--------v--------+                                       +--------v--------+
-     | App instance A   |                                       | App instance B   |
-     |                  |                                       |                  |
-     |  +------------+  |                                       |  +------------+  |
-     |  | Config     |  |                                       |  | Config     |  |
-     |  | interface  |  |                                       |  | interface  |  |
-     |  +-----+------+  |                                       |  +-----+------+  |
-     |        |         |                                       |        |         |
-     |  +-----v------+  |                                       |  +-----v------+  |
-     |  | Local cache|  |                                       |  | Local cache|  |
-     |  +-----+------+  |                                       |  +-----+------+  |
-     |        |         |                                       |        |         |
-     |  +-----v------+  |                                       |  +-----v------+  |
-     |  | Fallback   |  |                                       |  | Fallback   |  |
-     |  | (baked in  |  |                                       |  | (baked in  |  |
-     |  |  artifact) |  |                                       |  |  artifact) |  |
-     |  +------------+  |                                       |  +------------+  |
-     +------------------+                                       +------------------+
++--------------------------------------+
+| External Configuration Store         |
+| (Azure App Config / AWS AppConfig /  |
+| etcd / Consul / Spring Cloud Config) |
+|                                      |
+| key  rate.limit.checkout             |
+| val  500                             |
+| ver  42     label  production        |
++--------------------------------------+
+           ^  |
+     write |  | fetch / watch
+           |  v
+     +-----+--+-----+
+     |               |
+(App instance A)  (App instance B, identical shape)
 
-        A and B are two instances of the SAME application, or two
-        DIFFERENT applications sharing one setting. Both read the
-        same key from the same store, so both converge on the same
-        value once each cache refreshes.
++------------------+
+| Config interface |
++------------------+
+           |
+           v
++-------------+
+| Local cache |
++-------------+
+           |
+           v
++------------------------------+
+| Fallback (baked in artifact) |
++------------------------------+
+
+Each app instance independently fetches from and
+watches the store, reads through its local cache, and
+falls back to its baked-in artifact if the store is
+unreachable.
 ```
 
 ## 7. Dynamics

--- a/patterns/11-domain-driven-design/README.md
+++ b/patterns/11-domain-driven-design/README.md
@@ -2,7 +2,7 @@
 
 Origin. Evans, Vernon
 
-35 entries, 264,770 words. Every entry carries all 18
+35 entries, 264,744 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Anti-pattern
@@ -65,13 +65,13 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Bounded Context](bounded-context.md) | canonical | 6,827 | A software system of any real size accumulates more than one team, more than one department's worldview, and more than one legitimate meaning for the same word. |
 | [Conformist](conformist.md) | canonical | 6,538 | Two bounded contexts need to exchange data or invoke each other's behaviour, and one of the two, the upstream, owns a model neither side is free to renegotiate. |
 | [Context Canvas](context-canvas.md) | established | 7,622 | A team has decided, usually from an Event Storming session or from a Context Map already in hand, that a particular slice of the domain deserves its own bounded context. |
-| [Context Map](context-map.md) | canonical | 7,312 | A system reaches a certain size and a certain number of contributing teams before a single, internally consistent domain model stops being achievable. |
+| [Context Map](context-map.md) | canonical | 7,294 | A system reaches a certain size and a certain number of contributing teams before a single, internally consistent domain model stops being achievable. |
 | [Core Domain](core-domain.md) | canonical | 6,670 | A team building a non-trivial system faces a resource allocation problem long before it faces a technical one. |
 | [Customer-Supplier](customer-supplier.md) | canonical | 7,914 | Any system large enough to be split across more than one Bounded Context, see the bounded-context entry in this repository, produces integration points where one context's model ... |
 | [Open Host Service](open-host-service.md) | canonical | 9,358 | A bounded context that has real internal complexity attracts multiple downstream consumers over time. |
 | [Partnership](partnership.md) | canonical | 7,024 | Two teams each own a Bounded Context, and the two Contexts must integrate, but neither team can honestly claim to be upstream of the other. |
 | [Separate Ways](separate-ways.md) | canonical | 9,250 | A team splits a system into more than one Bounded Context for good reasons, because two departments' vocabularies genuinely diverge, because two teams cannot coordinate closely ... |
-| [Shared Kernel](shared-kernel.md) | canonical | 7,408 | Two Bounded Contexts model a piece of the domain in a compatible way, not because either team designed it that way on purpose, but because the concept genuinely is the same ... |
+| [Shared Kernel](shared-kernel.md) | canonical | 7,403 | Two Bounded Contexts model a piece of the domain in a compatible way, not because either team designed it that way on purpose, but because the concept genuinely is the same ... |
 | [Subdomain Discovery](subdomain-discovery.md) | established | 7,371 | A team about to build or re-architect a nontrivial system faces a boundary problem before it faces a single line of code. |
 | [Supporting Subdomain](supporting-subdomain.md) | canonical | 6,681 | A team building a system of real size eventually owns far more functionality than any one part of the business actually differentiates on. |
 
@@ -97,7 +97,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
-| [Domain Primitive](domain-primitive.md) | canonical | 7,263 | A codebase accretes validation logic at the edges and loses track of where the truth lives. |
+| [Domain Primitive](domain-primitive.md) | canonical | 7,260 | A codebase accretes validation logic at the edges and loses track of where the truth lives. |
 | [Entity](entity.md) | canonical | 7,973 | Every large domain contains two very different kinds of things, and conflating them is one of the most common sources of subtle correctness bugs in business software. |
 
 ## Reading order

--- a/patterns/11-domain-driven-design/context-map.md
+++ b/patterns/11-domain-driven-design/context-map.md
@@ -244,34 +244,47 @@ Map figures.
 ## 6. ASCII structure diagram
 
 ```
-+-----------------------------+          U/D          +---------------------+
-|   Billing Context           |----------------------->|  Payment Gateway    |
-|   (Sales subdomain)         |   Conformist            |  (third-party,     |
-|                              |   D: no negotiation     |   upstream)         |
-+---------------+--------------+                        +---------------------+
-                |
-                | Anticorruption Layer
-                | D: Billing owns translation
-                v
-+-----------------------------+   Open Host Service     +---------------------+
-|   Support Context           |<------------------------|  Published Lang.    |
-|   (Support subdomain)       |   U: exposes stable API |  (shared JSON       |
-|                              |   contract               |  ticket schema)     |
-+---------------+--------------+                        +---------------------+
-                |
-                | Shared Kernel
-                | (jointly owned "Account" module)
-                v
-+-----------------------------+                        +---------------------+
-|   Identity Context           |<----------------------|  Legacy Order System |
-|   (Core subdomain)           |   Conformist            |  (upstream, no      |
-|                               |   D: no negotiation     |   negotiation)      |
-+-------------------------------+                        +---------------------+
++-----------------------------------+
+| Billing Context (Sales subdomain) |
++-----------------------------------+
+           | Conformist, U/D, D: no negotiation
+           v
++-----------------------------------------+
+| Payment Gateway (third-party, upstream) |
++-----------------------------------------+
 
-+-----------------------------+          Separate Ways          +----------------+
-|   Marketing Analytics        |<--------------------------------|  Support        |
-|   (no integration needed)    |          no connection drawn    |  Context        |
-+-----------------------------+                                  +----------------+
++-------------------------------------+
+| Support Context (Support subdomain) |
++-------------------------------------+
+           ^
+           | Open Host Service, U: exposes stable
+           | API contract
++---------------------------------------------+
+| Published Lang. (shared JSON ticket schema) |
++---------------------------------------------+
+
+Billing -> Support: Anticorruption Layer, D: Billing
+owns translation.
+
++-----------------------------------+
+| Identity Context (Core subdomain) |
++-----------------------------------+
+           ^
+           | Conformist, D: no negotiation
++------------------------------------------------+
+| Legacy Order System (upstream, no negotiation) |
++------------------------------------------------+
+
+Support -> Identity: Shared Kernel (jointly owned
+"Account" module).
+
++---------------------------------------------+
+| Marketing Analytics (no integration needed) |
++---------------------------------------------+
+           . Separate Ways, no connection drawn
++-----------------+
+| Support Context |
++-----------------+
 ```
 
 ## 7. Dynamics

--- a/patterns/11-domain-driven-design/domain-primitive.md
+++ b/patterns/11-domain-driven-design/domain-primitive.md
@@ -251,36 +251,38 @@ the more important half of the dimension and the one most catalogs skip.
 ## 6. ASCII structure diagram
 
 ```
-                     +-----------------------------+
-                     |  Domain Primitive             |
-                     |  (e.g. EmailAddress)          |
-                     +-------------------------------+
-                     | - value: String  (private)    |
-                     +-------------------------------+
-                     | + of(raw: String): Result      |<-- validates, never throws
-                     | + toString(): String            |     across a trust boundary
-                     | + equals(other): boolean         |
-                     | + hashCode(): int                 |
-                     +-------------------------------+
-                              ^ constructed by
-                              |
-        +---------------------+---------------------+
-        |                                             |
-+---------------+                          +----------------------+
-| Boundary       |  raw String, int, etc.  | Validation rule set   |
-| translator     |------------------------->| (inline or delegated |
-| (controller,   |                          |  to a Specification) |
-| deserializer)  |                          +----------------------+
-+---------------+
-        |
-        | constructs, on success
-        v
++--------------------------------------+
+| Domain Primitive (e.g. EmailAddress) |
+| value: String  (private)             |
+| of(raw: String): Result              |
+| toString(): String                   |
+| equals(other): boolean               |
+| hashCode(): int                      |
++--------------------------------------+
+(of() validates, never throws across a trust boundary)
+           ^ constructed by
+           |
+     +-----+-----+
+     |           |
++---------------------+ +---------------------+
+| Boundary translator | | Validation rule set |
+| (controller,        | | (inline or delegated|
+| deserializer)       | | to a Specification) |
++---------------------+ +---------------------+
+
+(raw String, int, etc. flows from translator into
+the rule set)
+
+     |
+     | constructs, on success
+     v
 +----------------------------------------------+
-| Consumer (application service, Entity field,  |
-| another Domain Primitive)                     |
+| Consumer (application service, Entity field, |
+| another Domain Primitive)                    |
 +----------------------------------------------+
-        never receives the raw, unvalidated
-        primitive once this boundary is crossed
+
+Never receives the raw, unvalidated primitive once
+this boundary is crossed.
 ```
 
 ## 7. Dynamics

--- a/patterns/11-domain-driven-design/saga-versus-process-manager.md
+++ b/patterns/11-domain-driven-design/saga-versus-process-manager.md
@@ -304,38 +304,51 @@ skip:
 ```
 CHOREOGRAPHY (no Process Manager, no central object)
 
-   +-------------+  OrderCreated   +-------------+  PaymentCharged  +-------------+
-   |    Order    | -------------> |   Payment   | --------------> |  Inventory  |
-   |   Service   |                |   Service   |                 |   Service   |
-   +-------------+                +-------------+                 +-------------+
-         ^                              |                                |
-         | PaymentFailed                | InventoryReservationFailed     |
-         +------------------------------+--------------------------------+
-   No single object holds the whole flow. Each arrow is a pub/sub event.
++---------------+
+| Order Service |
++---------------+
+           | OrderCreated
+           v
++-----------------+
+| Payment Service |
++-----------------+
+           | PaymentCharged
+           v
++-------------------+
+| Inventory Service |
++-------------------+
+
+Failure paths, each its own pub/sub event:
+  Payment Service --PaymentFailed--> Order Service
+  Inventory Service --InventoryReservationFailed-->
+  Order Service
+
+No single object holds the whole flow. Each arrow
+is a pub/sub event.
 
 
-ORCHESTRATION (a Process Manager coordinates the same steps)
+ORCHESTRATION (a Process Manager coordinates the
+same steps)
 
-                          +----------------------------+
-                          |   Order Saga Orchestrator   |
-                          |  (a Process Manager)        |
-                          |  state = AWAITING_PAYMENT   |
-                          +----------------------------+
-                             |  command        ^ reply
-                             v                 |
-                          +-------------+
-                          |   Payment   |
-                          |   Service   |
-                          +-------------+
-                             |  command        ^ reply
-                             v                 |
-                          +-------------+
-                          |  Inventory  |
-                          |   Service   |
-                          +-------------+
++--------------------------+
+| Order Saga Orchestrator  |
+| (a Process Manager)      |
+| state = AWAITING_PAYMENT |
++--------------------------+
+           | command      ^ reply
+           v              |
++-----------------+
+| Payment Service |
++-----------------+
+           | command      ^ reply
+           v              |
++-------------------+
+| Inventory Service |
++-------------------+
 
-   The orchestrator sends one command at a time and owns the whole
-   sequence. Participants know only the orchestrator, not each other.
+The orchestrator sends one command at a time and
+owns the whole sequence. Participants know only the
+orchestrator, not each other.
 ```
 
 ## 7. Dynamics

--- a/patterns/11-domain-driven-design/shared-kernel.md
+++ b/patterns/11-domain-driven-design/shared-kernel.md
@@ -244,29 +244,30 @@ depends on.
 ## 6. ASCII structure diagram
 
 ```
-+-----------------------------+          +-----------------------------+
-|   Bounded Context. Billing  |          | Bounded Context. Fulfillment|
-|   (owned by Team Billing)   |          | (owned by Team Fulfillment) |
-|                              |          |                              |
-|  Invoice, Payment,           |          |  Shipment, Route,            |
-|  BillingAccount               |          |  DeliveryWindow              |
-+---------------+---------------+          +---------------+---------------+
-                |                                            |
-                | imports / depends on                       | imports / depends on
-                v                                            v
-        +-------------------------------------------------------+
-        |                     SHARED KERNEL                     |
-        |  Money (currency, amount, rounding rule)               |
-        |  OrderId (identifier type, equality, parsing)          |
-        |  ShipmentRequested (domain event, field shape)         |
-        +-------------------------------------------------------+
-                                    |
-                                    | governed by
-                                    v
-                +---------------------------------------+
-                |  Joint review + shared CI + version tag |
-                |  (both teams sign off, both teams test) |
-                +---------------------------------------+
++------------------------------+ +------------------------------+
+| Bounded Context: Billing     | | Bounded Context: Fulfillment |
+| (owned by Team Billing)      | | (owned by Team Fulfillment)  |
+|                              | |                              |
+| Invoice, Payment,            | | Shipment, Route,             |
+| BillingAccount               | | DeliveryWindow               |
++------------------------------+ +------------------------------+
+     |                          |
+     +-----------+--------------+
+         imports / depends on
+                 v
++-----------------------------------------------+
+| SHARED KERNEL                                 |
+| Money (currency, amount, rounding rule)       |
+| OrderId (identifier type, equality, parsing)  |
+| ShipmentRequested (domain event, field shape) |
++-----------------------------------------------+
+                 |
+                 | governed by
+                 v
++----------------------------------------+
+| Joint review + shared CI + version tag |
+| (both teams sign off, both teams test) |
++----------------------------------------+
 ```
 
 The kernel sits below both contexts, not beside them, because it is a

--- a/patterns/12-data-storage/README.md
+++ b/patterns/12-data-storage/README.md
@@ -2,7 +2,7 @@
 
 Origin. Kleppmann
 
-45 entries, 319,830 words. Every entry carries all 18
+45 entries, 319,818 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Concurrency Control
@@ -48,13 +48,13 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [LSM Tree](lsm-tree.md) | canonical | 9,064 | A key-value or wide-column store needs to sustain a high rate of writes, including writes that touch keys scattered across the entire key space, while still answering point ... |
 | [Lamport Clock](lamport-clock.md) | canonical | 6,460 | A distributed system has no shared memory and no shared clock. |
 | [Leaderless Replication](leaderless-replication.md) | canonical | 7,925 | A single-leader replicated database routes every write through one node. |
-| [Log Compaction](log-compaction.md) | established | 8,043 | An append-only log is the simplest and most dependable storage primitive a distributed system offers. |
+| [Log Compaction](log-compaction.md) | established | 8,019 | An append-only log is the simplest and most dependable storage primitive a distributed system offers. |
 | [Medallion Architecture](medallion-architecture.md) | established | 7,094 | A data platform ingests information from many upstream systems. |
 | [Multi-Leader Replication](multi-leader-replication.md) | established | 7,906 | A team runs a database that serves write traffic from more than one geographic region, or from more than one autonomous system that must keep working during a network partition ... |
 | [Multiversion Concurrency Control](mvcc.md) | canonical | 7,230 | A database serves many concurrent transactions. |
 | [Quorum](quorum.md) | canonical | 7,448 | A system replicates the same piece of data onto several nodes so that the loss of any one node, or the temporary unavailability of any one node, does not lose data or stop the ... |
 | [Read Repair](read-repair.md) | canonical | 6,416 | A system with leaderless, quorum-based replication accepts writes on any of several replicas for a key, and a temporarily unreachable replica, a dropped message, or a slow node ... |
-| [Read-Through Cache](read-through-cache.md) | canonical | 7,970 | An application reads the same piece of data far more often than the data changes. |
+| [Read-Through Cache](read-through-cache.md) | canonical | 7,982 | An application reads the same piece of data far more often than the data changes. |
 | [Slowly Changing Dimensions](slowly-changing-dimensions.md) | canonical | 7,737 | A dimensional data warehouse separates numeric, frequently-recorded facts (an order line, a sensor reading, a page view) from the descriptive dimensions those facts are analyzed ... |
 | [Snowflake Schema](snowflake-schema.md) | canonical | 7,439 | A team building a data warehouse or a semantic model for business intelligence needs to answer analytical questions fast, total revenue by region and month, units sold by product ... |
 | [Star Schema](star-schema.md) | canonical | 7,771 | An organization accumulates a large volume of business events, orders, shipments, page views, sensor readings, trades. |

--- a/patterns/12-data-storage/log-compaction.md
+++ b/patterns/12-data-storage/log-compaction.md
@@ -236,36 +236,42 @@ avoid the fixed overhead of a compaction pass for marginal space savings.
 ## 6. ASCII structure diagram
 
 ```
-                              PARTITION (single log)
-  +------------------------------------------------------------------+
-  |  TAIL (compacted, <=1 record/key)  |  HEAD (dirty, duplicates ok) |
-  |  segment.0   segment.1  segment.2  |   segment.3     segment.4    |
-  |  [k1=v1]     [k3=v2]    [k2=v3]    |   [k1=v4][k3=T] [k4=v5][k1=v6]|
-  +------------------------------------------------------------------+
-        ^ closed, immutable                    ^ segment.4 = active
-        |                                       | (still being appended)
-        |                                       |
-        +---- log cleaner reads dirty segments --+
-              builds offset map, key to highest offset
-              rewrites tail with duplicates dropped, tombstones kept
-              (tombstones dropped only after delete.retention.ms elapses)
+PARTITION (single log)
 
-  Cleaner selection loop (one pass, repeats):
+TAIL (compacted, <=1 record/key), closed, immutable
+  segment.0   segment.1   segment.2
+  [k1=v1]     [k3=v2]     [k2=v3]
 
-    for each partition P in cluster (round robin by dirty ratio):
-        dirty_ratio = bytes(head(P)) / bytes(P)
-        if dirty_ratio < min.cleanable.dirty.ratio:
-            skip P this round
-        else:
-            build_offset_map(head(P))          # key -> highest offset
-            for segment in dirty_segments(P):
-                for record in segment:
-                    if record.offset == offset_map[record.key]:
-                        keep record             # this IS the latest
-                    elif record.is_tombstone and age(record) < delete.retention.ms:
-                        keep record             # grace window
-                    else:
-                        drop record              # superseded, space freed
+HEAD (dirty, duplicates ok)
+  segment.3         segment.4 (active,
+  [k1=v4][k3=T]     still being appended)
+                    [k4=v5][k1=v6]
+
+log cleaner reads dirty segments (HEAD), then:
+  builds offset map, key to highest offset
+  rewrites TAIL with duplicates dropped,
+  tombstones kept (tombstones dropped only
+  after delete.retention.ms elapses)
+
+Cleaner selection loop (one pass, repeats):
+
+for each partition P in cluster (round robin by
+dirty ratio):
+    dirty_ratio = bytes(head(P)) / bytes(P)
+    if dirty_ratio < min.cleanable.dirty.ratio:
+        skip P this round
+    else:
+        build_offset_map(head(P))  # key -> offset
+        for segment in dirty_segments(P):
+            for record in segment:
+                if record.offset ==
+                   offset_map[record.key]:
+                    keep record  # latest
+                elif record.is_tombstone and
+                     age(record) < delete.retention.ms:
+                    keep record  # grace window
+                else:
+                    drop record  # superseded
 ```
 
 ## 7. Dynamics

--- a/patterns/12-data-storage/read-through-cache.md
+++ b/patterns/12-data-storage/read-through-cache.md
@@ -254,25 +254,37 @@ depends on both the Cache and the Origin and coordinates between them itself.
 ## 6. ASCII structure diagram
 
 ```
-      +-------------+          +---------------------+          +-----------+
-      |   Client    |  get(k)  |        Cache         |  load(k) |  Loader   |
-      |-------------|--------->|----------------------|--------->|-----------|
-      | (no origin  |          | map<K,V> store        |          | fetch(K):V|
-      |  dependency)|<---------| eviction policy (TTL, |<---------|           |
-      +-------------+  value   | size bound)           |  value   +-----------+
-                                +----------+-----------+                |
-                                           ^                            | query
-                                           |                            v
-                                     (cache hit path,               +-----------+
-                                      no Loader call)                |  Origin   |
-                                                                      | database, |
-                                                                      | API, or   |
-                                                                      | expensive |
-                                                                      | compute   |
-                                                                      +-----------+
++-------------------------------+
+| Client (no origin dependency) |
++-------------------------------+
+           | get(k)
+           v
++-----------------------------------+
+| Cache                             |
+| map<K,V> store                    |
+| eviction policy (TTL, size bound) |
++-----------------------------------+
+           | value, returned to Client above
+           |
+           | load(k), only on a cache miss
+           v
++-------------+
+| Loader      |
+| fetch(K): V |
++-------------+
+           | value, returned to Cache above
+           |
+           | query
+           v
++-------------------------------------+
+| Origin                              |
+| database, API, or expensive compute |
++-------------------------------------+
 
-   The Client's only compile time dependency is Cache. Origin is reachable
-   only through Loader, which the Cache owns and calls, never the Client.
+A cache hit answers from the Cache directly, no Loader
+call. The Client's only compile-time dependency is
+Cache. Origin is reachable only through Loader, which
+the Cache owns and calls, never the Client.
 ```
 
 ## 7. Dynamics

--- a/patterns/14-testing/README.md
+++ b/patterns/14-testing/README.md
@@ -2,14 +2,14 @@
 
 Origin. Meszaros, xUnit Test Patterns
 
-30 entries, 217,027 words. Every entry carries all 18
+30 entries, 217,017 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Test Data
 
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
-| [Derived Value](derived-value.md) | canonical | 5,157 | A test needs data. Every object under test, and every collaborator it talks to, has fields that must be filled in before the test can run, and the overwhelming majority of those ... |
+| [Derived Value](derived-value.md) | canonical | 5,147 | A test needs data. Every object under test, and every collaborator it talks to, has fields that must be filled in before the test can run, and the overwhelming majority of those ... |
 | [Generated Value](generated-value.md) | canonical | 6,233 | A fixture object almost always has more fields than the test actually cares about. |
 
 ## Test Double

--- a/patterns/14-testing/derived-value.md
+++ b/patterns/14-testing/derived-value.md
@@ -163,20 +163,27 @@ never need to know, and should not depend on, how the value was produced.
 ## 6. ASCII structure diagram
 
 ```
-+---------------------+     +------------------------+     +----------------+
-|        Seed          |     |   Derivation Function   |     | Derived Value  |
-|-----------------------|---->|--------------------------|---->|----------------|
-| counter, test name,   |     | prefix + seed            |     | "user-0007"    |
-| or a sibling field     |     | hash(seed) mod range      |     | (unique, or    |
-|                        |     | slugify(title)            |     |  consistent    |
-+---------------------+     +------------------------+     |  with sibling) |
-                                                             +----------------+
-                                                                     |
-                                                                     v
-                                                             +----------------+
-                                                             | Fixture Object |
-                                                             | under test     |
-                                                             +----------------+
++---------------------+
+| Seed                |
+| counter, test name, |
+| or a sibling field  |
++---------------------+
+           v
++----------------------+
+| Derivation Function  |
+| prefix + seed        |
+| hash(seed) mod range |
+| slugify(title)       |
++----------------------+
+           v
++--------------------------------------+
+| Derived Value: "user-0007"           |
+| (unique, or consistent with sibling) |
++--------------------------------------+
+           v
++---------------------------+
+| Fixture Object under test |
++---------------------------+
 ```
 
 ## 7. Dynamics


### PR DESCRIPTION
## Summary

- Redraws ten more ASCII diagrams that exceeded 78 characters wide, the
  next tier at 83 to 84 characters, down to 40 to 65 characters.
- domain-primitive.md, context-map.md, external-configuration-store.md,
  context-object.md, metadata-mapping.md, derived-value.md,
  read-through-cache.md, log-compaction.md, shared-kernel.md,
  saga-versus-process-manager.md.
- No structural, prose, reference, or code content changed. Only the
  diagram fences.
- tools/gen-indexes.py was re-run before this commit, regenerating the
  five family index tables these entries span.

## Notable redesigns

- context-map.md's four DDD relationship pairs (Billing to Payment
  Gateway, Support to Published Language, Identity to Legacy Order
  System, Marketing Analytics to Support) were four arrows on one wide
  graph. They are now four separate stacked mini diagrams, each edge
  label preserved as a prose line beneath it.
- saga-versus-process-manager.md's choreography section, a three box
  horizontal chain with two failure path pub or sub events, became a
  vertical stack with the failure paths written out as prose bullets
  below the happy path.
- shared-kernel.md keeps its two Bounded Context boxes as a genuine
  side by side pair, since that parallel structure is the point of the
  pattern, narrowed to a shared 30 character column width feeding one
  merged Shared Kernel box below.

## Test plan

- [x] check-structure.py, 884 of 884 entries pass
- [x] check-prose.py, 925 of 925 entries pass
- [x] markdownlint-cli2 0.23.2, 0 issues on the ten changed files
- [x] validate-refs.py --strict, every citation resolves
- [x] check-code.py --strict, 2826 compiled, 0 failed, 0 skipped
- [x] gen-indexes.py re-run, five family README tables regenerated and
      committed alongside the content changes
- [x] git diff --stat -- docs and dist and the root README.md, all
      empty, no unexpected top level changes

67 more entries with the same width issue remain, to be worked through
in following batches.
