### PR TITLE
fix(patterns) redraw ten more ASCII diagrams under 78 columns

### DIFF
--- a/patterns/02-code-smells/README.md
+++ b/patterns/02-code-smells/README.md
@@ -2,7 +2,7 @@
 
 Origin. Fowler and Beck, Refactoring
 
-28 entries, 221,148 words. Every entry carries all 18
+28 entries, 221,153 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Bloaters
@@ -49,7 +49,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Inappropriate Intimacy](inappropriate-intimacy.md) | canonical | 8,379 | Two classes end up knowing far more about each other's insides than either one's public contract admits to. |
 | [Incomplete Library Class](incomplete-library-class.md) | canonical | 8,434 | A team depends on a class, module, or type that ships from outside the codebase they control. |
 | [Insider Trading](insider-trading.md) | canonical | 8,077 | Two modules were designed to talk to each other through a small, deliberate interface, and over time they grew a second, informal interface nobody designed. |
-| [Message Chains](message-chains.md) | canonical | 6,586 | A client asks one object for a second object, then immediately asks that second object for a third, and continues down the line until it finally reads or calls the field it ... |
+| [Message Chains](message-chains.md) | canonical | 6,591 | A client asks one object for a second object, then immediately asks that second object for a third, and continues down the line until it finally reads or calls the field it ... |
 | [Shotgun Surgery](shotgun-surgery.md) | canonical | 7,839 | A team ships a single logical concept, adding a new payment method, adding a new shipping carrier, adding a new order status, renaming a field that a dozen call sites read. |
 
 ## Object-Orientation Abusers

--- a/patterns/02-code-smells/feature-envy.md
+++ b/patterns/02-code-smells/feature-envy.md
@@ -228,26 +228,42 @@ existing code rather than designed in advance.
 ## 6. ASCII structure diagram
 
 ```
-  Before                              After
+Before
 
-  +----------------+                  +----------------+
-  | InvoicePrinter  |                 | InvoicePrinter  |
-  |----------------|                  |----------------|
-  | +priceFor(c,amt)|--calls-->       | +priceFor(c,amt)|--calls-->
-  +----------------+       |          +----------------+       |
-         |                 |                                    |
-         | reads mostly    |          +----------------+        |
-         v                 |          |    Customer    |<-------+
-  +----------------+       |          |----------------|
-  |    Customer    |<------+          | -discountRate  |
-  |----------------|                  | -loyaltyYears  |
-  | -discountRate  |                  | -isWholesale   |
-  | -loyaltyYears  |                  | +priceFor(amt) |  <- rule now
-  | -isWholesale   |                  +----------------+     lives beside
-  +----------------+                                          its own data
++-----------------------------+
+| InvoicePrinter              |
+| +priceFor(customer, amount) |
++-----------------------------+
+           | reads customer's fields directly
+           v
++---------------+
+| Customer      |
+| -discountRate |
+| -loyaltyYears |
+| -isWholesale  |
++---------------+
 
-  Legend. InvoicePrinter.priceFor reads Customer's fields more    Customer.priceFor
-  than its own state, the envy.                                   reads only self.
+InvoicePrinter.priceFor reads Customer's fields more
+than its own state. That is the envy.
+
+
+After
+
++-----------------------------+
+| InvoicePrinter              |
+| +priceFor(customer, amount) |
++-----------------------------+
+           | delegates to
+           v
++----------------------------------------------------------+
+| Customer                                                 |
+| -discountRate                                            |
+| -loyaltyYears                                            |
+| -isWholesale                                             |
+| +priceFor(amount)  <- rule now lives beside its own data |
++----------------------------------------------------------+
+
+Customer.priceFor reads only its own state.
 ```
 
 ## 7. Dynamics

--- a/patterns/02-code-smells/message-chains.md
+++ b/patterns/02-code-smells/message-chains.md
@@ -223,34 +223,55 @@ client calls one method instead of walking the chain itself.
 ```
 BEFORE, message chain
 
-  +--------+   .customer   +----------+   .address   +---------+
-  | Client |-------------->| Head     |------------->| Interm. |
-  +--------+               | (Order)  |              |(Custmr) |
-      |                    +----------+              +---------+
-      |                                                    |
-      | client reaches through Order and Customer          | .address
-      | to touch Address directly                          v
-      |                                              +---------+   .zipCode
-      +--------------------------------------------->| Interm. |----------> target
-                                                       |(Address)|
-                                                       +---------+
++--------+
+| Client |
++--------+
+     | .customer
+     v
++--------------+
+| Head (Order) |
++--------------+
+     | .address
+     v
++-------------------------+
+| Intermediate (Customer) |
++-------------------------+
+     | .address
+     v
++------------------------+
+| Intermediate (Address) |
++------------------------+
+     | .zipCode
+     v
+target
+
+Client reaches through Order and Customer to touch
+Address directly, one accessor call per hop.
 
 AFTER, Hide Delegate applied
 
-  +--------+  .shippingZip()   +----------+
-  | Client |------------------>| Head     |
-  +--------+                   | (Order)  |
-                                +----------+
-                                     |
-                                     | Order.shippingZip() internally
-                                     | walks customer.address.zipCode
-                                     v
-                          +----------+     +---------+
-                          | Customer |---->| Address |
-                          +----------+     +---------+
++--------+
+| Client |
++--------+
+     | .shippingZip()
+     v
++--------------+
+| Head (Order) |
++--------------+
+     | internally walks customer.address.zipCode
+     v
++----------+
+| Customer |
++----------+
+     |
+     v
++---------+
+| Address |
++---------+
 
-  Client now depends on Order alone. Customer and Address are private
-  implementation detail of how Order answers the question.
+Client now depends on Order alone. Customer and Address
+are private implementation detail of how Order answers
+the question.
 ```
 
 ## 7. Dynamics

--- a/patterns/03-refactoring/introduce-assertion.md
+++ b/patterns/03-refactoring/introduce-assertion.md
@@ -138,14 +138,23 @@ The refactoring has one participant.
 ## 6. ASCII structure diagram
 
 ```
-  BEFORE                              AFTER
-  ------                              -----
+BEFORE
+------
 
-  def calculate(distance, time):      def calculate(distance, time):
-      return distance / time              assert time != 0, "time must be non-zero"
-                                          return distance / time
+def calculate(distance, time):
+    return distance / time
 
-  (no check, assumption implicit)     (assertion makes assumption explicit)
+(no check, assumption implicit)
+
+
+AFTER
+-----
+
+def calculate(distance, time):
+    assert time != 0, "time must be non-zero"
+    return distance / time
+
+(assertion makes assumption explicit)
 ```
 
 ## 7. Dynamics

--- a/patterns/03-refactoring/preserve-whole-object.md
+++ b/patterns/03-refactoring/preserve-whole-object.md
@@ -118,16 +118,26 @@ whole object as a single parameter.
 ## 6. ASCII structure diagram
 
 ```
-  BEFORE                              AFTER
-  ------                              -----
+BEFORE
+------
 
-  charge(nights, rate, taxRate)       charge(room)
-    // uses nights, rate, taxRate      // uses room.nights, room.rate, room.taxRate
+charge(nights, rate, taxRate)
+  // uses nights, rate, taxRate
 
-  caller:                             caller:
-    charge(room.nights,                 charge(room)
-           room.rate,
-           room.taxRate)
+caller:
+  charge(room.nights,
+         room.rate,
+         room.taxRate)
+
+
+AFTER
+-----
+
+charge(room)
+  // uses room.nights, room.rate, room.taxRate
+
+caller:
+  charge(room)
 ```
 
 ## 7. Dynamics

--- a/patterns/04-principles-and-laws/README.md
+++ b/patterns/04-principles-and-laws/README.md
@@ -2,7 +2,7 @@
 
 Origin. Martin, Larman, Brewer, Conway
 
-42 entries, 327,261 words. Every entry carries all 18
+42 entries, 327,241 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Design Principle
@@ -53,7 +53,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Pure Fabrication](pure-fabrication.md) | canonical | 7,604 | A designer following Information Expert as the default rule will, for a large share of responsibilities, land on the right class without further thought. |
 | [Release Reuse Equivalence](release-reuse-equivalence.md) | canonical | 8,321 | The problem REP addresses shows up the moment more than one piece of software wants to depend on the same piece of source code. |
 | [Separation of Concerns](separation-of-concerns.md) | canonical | 10,250 | A codebase grows by accretion. A new requirement lands, and the fastest way to satisfy it is to add a few lines wherever the relevant data already sits in memory. |
-| [Single Responsibility Principle](single-responsibility-principle.md) | canonical | 8,417 | The problem SRP names is a specific, recognizable shape of decay. |
+| [Single Responsibility Principle](single-responsibility-principle.md) | canonical | 8,408 | The problem SRP names is a specific, recognizable shape of decay. |
 | [Single Source of Truth](single-source-of-truth.md) | canonical | 8,258 | A fact about the world gets written down more than once, in more than one system, in more than one file, or in more than one variable, because writing it again was faster than ... |
 | [Stable Dependencies Principle](stable-dependencies-principle.md) | canonical | 8,881 | A system of any real size is built from more than one compilation or deployment unit, whatever the language calls that unit, a package, a module, a JAR, a crate, an npm package ... |
 | [Tell, Don't Ask](tell-do-not-ask.md) | canonical | 9,194 | The problem this principle answers shows up the first time a codebase grows past the size where one person holds the whole design in their head. |
@@ -64,7 +64,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
 | [Liskov Substitution Principle](liskov-substitution-principle.md) | canonical | 6,210 | Object-oriented languages let a caller hold a reference typed as a base class or an interface and receive, at runtime, any one of several concrete subtypes. |
-| [Polymorphism](polymorphism.md) | canonical | 7,463 | A piece of client code needs to perform an operation, render a shape, calculate a price, serialize a value, and it needs to do so uniformly over a collection of things that are ... |
+| [Polymorphism](polymorphism.md) | canonical | 7,452 | A piece of client code needs to perform an operation, render a shape, calculate a price, serialize a value, and it needs to do so uniformly over a collection of things that are ... |
 
 ## Structural principle
 

--- a/patterns/04-principles-and-laws/polymorphism.md
+++ b/patterns/04-principles-and-laws/polymorphism.md
@@ -211,28 +211,41 @@ the performance force from dimension 3 lives.
 ## 6. ASCII structure diagram
 
 ```
-        Client                    Abstraction                Concrete
-        (caller)                  (interface / protocol)     Implementations
++-----------------------------+
+| Client (caller)             |
+| holds reference typed Shape |
++-----------------------------+
+           | calls process(shape) -> s.area()
+           v
++------------------------------+
+| Abstraction, interface Shape |
+| area(): number               |
+| perimeter(): number          |
++------------------------------+
+           ^
+           | implemented by three concrete classes
 
-  +----------------+          +----------------------+     +----------------+
-  |  process(shape) |-------->|  interface Shape      |<----|  Circle        |
-  |                  |  calls |    area(): number      |     |  area() { ... } |
-  |  holds reference |        |    perimeter(): number |     +----------------+
-  |  typed Shape     |        +----------------------+     +----------------+
-  +------------------+                   ^                  |  Square        |
-                                          | implements       |  area() { ... } |
-                                          |                   +----------------+
-                                          |                  +----------------+
-                                          +------------------|  Triangle      |
-                                                             |  area() { ... } |
-                                                             +----------------+
++----------------+
+| Circle         |
+| area() { ... } |
++----------------+
++----------------+
+| Square         |
+| area() { ... } |
++----------------+
++----------------+
+| Triangle       |
+| area() { ... } |
++----------------+
 
-  Binder (runtime dispatch mechanism, one per language runtime):
+Binder, the runtime dispatch mechanism, one per language
+runtime.
 
-  C++ / Java   ->  vtable pointer inside the object header, indexed lookup
-  Go           ->  interface value = (type descriptor, data pointer), itable lookup
-  Rust dyn     ->  fat pointer = (data pointer, vtable pointer)
-  Python/Ruby  ->  method resolution order (MRO) walk on the object's class
+  C++/Java   vtable pointer in the object header, indexed
+  Go         interface value (type descriptor, data
+             pointer), itable lookup
+  Rust dyn   fat pointer (data pointer, vtable pointer)
+  Python/Ruby   method resolution order walk on the class
 ```
 
 ## 7. Dynamics

--- a/patterns/04-principles-and-laws/single-responsibility-principle.md
+++ b/patterns/04-principles-and-laws/single-responsibility-principle.md
@@ -243,38 +243,40 @@ that appear whenever SRP is applied concretely.
 ## 6. ASCII structure diagram
 
 ```
-  Before                                After
+Before
 
-  +----------------------+              +-----------------------+
-  |       Invoice        |              |   InvoiceCalculator   |
-  |----------------------|              |------------------------|
-  | fields: lines, tax   |              | + total(inv): Money   |
-  |----------------------|              +-----------------------+
-  | + total(): Money     |  <- finance             ^
-  | + print(): String    |  <- layout team          |  reads
-  | + save(db): void     |  <- storage team          |
-  +----------------------+              +-----------------------+
-                                          |       Invoice        |
-                                          |  (data only, no      |
-                                          |   behaviour beyond   |
-                                          |   its own shape)     |
-                                          +-----------------------+
-                                                     ^
-                                     reads            |            reads
-                                          +-----------+-----------+
-                                          |                       |
-                              +-----------------------+ +-----------------------+
-                              |    InvoicePrinter      | |  InvoiceRepository    |
-                              |------------------------| |------------------------|
-                              | + render(inv): String  | | + save(inv): void      |
-                              +-----------------------+ +-----------------------+
-                                     ^ answers to               ^ answers to
-                                layout / reporting team    storage / DBA team
++---------------------------------------+
+| Invoice                               |
+| fields: lines, tax                    |
+| + total(): Money      <- finance team |
+| + print(): String     <- layout team  |
+| + save(db): void      <- storage team |
++---------------------------------------+
 
-  Each right-hand box has exactly one actor who would ask it to change.
-  A change to tax law touches only InvoiceCalculator. A change to the PDF
-  layout touches only InvoicePrinter. A change to the storage schema
-  touches only InvoiceRepository. No single edit crosses two boxes.
+Three unrelated teams each have a reason to change this
+one class.
+
+
+After
+
++----------------------------------------------+
+| Invoice                                      |
+| data only, no behaviour beyond its own shape |
++----------------------------------------------+
+        ^                ^                ^
+        | reads          | reads          | reads
++-------------------+  +----------------+  +-------------------+
+| InvoiceCalculator |  | InvoicePrinter |  | InvoiceRepository |
+| + total(inv)      |  | + render(inv)  |  | + save(inv)       |
++-------------------+  +----------------+  +-------------------+
+      answers to        answers to        answers to
+      finance team       layout team       storage team
+
+Each box has exactly one actor who would ask it to change.
+A tax law change touches only InvoiceCalculator, a PDF
+layout change touches only InvoicePrinter, a storage
+schema change touches only InvoiceRepository. No single
+edit crosses two boxes.
 ```
 
 ## 7. Dynamics

--- a/patterns/05-architectural/README.md
+++ b/patterns/05-architectural/README.md
@@ -2,7 +2,7 @@
 
 Origin. Buschmann POSA 1, Bass SEI
 
-31 entries, 248,971 words. Every entry carries all 18
+31 entries, 248,947 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Architectural
@@ -35,7 +35,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Plugin Architecture](plugin-architecture.md) | canonical | 7,823 | An application needs to support a set of behaviours that is open-ended, unknown at the time the core is built, and likely to be supplied by parties who are not the core's own ... |
 | [Plugin Sandbox](plugin-sandbox.md) | established | 10,826 | A host application defines an extension point, using Plugin Architecture or Microkernel, so that its behavior can grow without every new feature being merged into the core ... |
 | [Primary-Replica](primary-replica.md) | canonical | 7,665 | A single database instance handling both writes and reads eventually hits a ceiling on at least one of three axes, read throughput, availability, and geographic latency. |
-| [Serverless Architecture](serverless-architecture.md) | established | 8,896 | A team owns a backend that must handle a workload with two properties that are hard to satisfy at once with a conventional server fleet, the load is spiky or unpredictable, and ... |
+| [Serverless Architecture](serverless-architecture.md) | established | 8,872 | A team owns a backend that must handle a workload with two properties that are hard to satisfy at once with a conventional server fleet, the load is spiky or unpredictable, and ... |
 | [Service-Oriented Architecture](service-oriented-architecture.md) | contested | 6,727 | A monolithic application starts as the fastest way to ship. |
 | [Shared Nothing](shared-nothing.md) | canonical | 7,785 | A system needs to handle more work than one machine can handle, whether that work is transaction throughput, storage volume, or concurrent connections. |
 | [Space-Based Architecture](space-based-architecture.md) | established | 7,002 | A system built as a stateless application tier in front of a single relational database scales the application tier easily and the database tier badly. |

--- a/patterns/05-architectural/serverless-architecture.md
+++ b/patterns/05-architectural/serverless-architecture.md
@@ -259,26 +259,33 @@ input and returns output or fails.
 ## 6. ASCII structure diagram
 
 ```
-   +----------------+   invokes    +----------------------+
-   |    Trigger     | -----------> |  Execution Environment |
-   | (API Gateway,  |              |  (created on demand,   |
-   |  Queue, Bucket, |              |   torn down when idle) |
-   |  Scheduler)     |              |  +-------------------+ |
-   +----------------+              |  |     Function      | |
-                                    |  | (stateless logic) | |
-                                    |  +---------+---------+ |
-                                    +------------|-----------+
-                                                 |
-                                reads / writes   |
-                          +----------------------+----------------------+
-                          |                      |                      |
-                 +----------------+   +------------------+   +------------------+
-                 | Managed Queue  |   | Managed Database  |   | Managed Storage  |
-                 |   (BaaS)       |   |    (BaaS)          |   |    (BaaS)        |
-                 +----------------+   +------------------+   +------------------+
++---------------------------------------+
+| Trigger                               |
+| API Gateway, Queue, Bucket, Scheduler |
++---------------------------------------+
+           | invokes
+           v
++----------------------------------------+
+| Execution Environment                  |
+| created on demand, torn down when idle |
+|                                        |
+|   Function (stateless logic)           |
++----------------------------------------+
+           | reads / writes
+           v
++----------------------+
+| Managed Queue (BaaS) |
++----------------------+
++-------------------------+
+| Managed Database (BaaS) |
++-------------------------+
++------------------------+
+| Managed Storage (BaaS) |
++------------------------+
 
-   Orchestrator (state machine or event bus) sequences several Functions,
-   each one independently triggered, none holding the workflow's state.
+Orchestrator, a state machine or event bus, sequences
+several Functions, each one independently triggered, none
+holding the workflow's state.
 ```
 
 ## 7. Dynamics

--- a/patterns/06-enterprise-application-architecture/README.md
+++ b/patterns/06-enterprise-application-architecture/README.md
@@ -2,7 +2,7 @@
 
 Origin. Fowler, PoEAA
 
-56 entries, 371,836 words, 4 more planned, 60 total when the family is complete. Every entry carries all 18
+56 entries, 371,825 words, 4 more planned, 60 total when the family is complete. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Base Pattern
@@ -77,7 +77,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Composite Entity](composite-entity.md) | established | 1,572 | A domain model made of many small, related objects, mapped one-to-one to individually remote, individually persistent components, pays a real network and management cost for every ... |
 | [Composite View](composite-view.md) | established | 1,561 | A page is commonly built from parts that are shared across many other pages, a header, a footer, a navigation block, and duplicating those shared parts directly inside every page ... |
 | [Connection Pooling](connection-pooling.md) | canonical | 1,662 | PostgreSQL's own documentation states the direct constraint this pattern works against. |
-| [Context Object](context-object.md) | established | 1,501 | A component or a service somewhere in an application needs access to system information, such as request parameters or configuration values, that originates from a specific ... |
+| [Context Object](context-object.md) | established | 1,490 | A component or a service somewhere in an application needs access to system information, such as request parameters or configuration values, that originates from a specific ... |
 | [Tolerant Reader](tolerant-reader.md) | established | 1,517 | Fowler's own text states the underlying problem directly. |
 | [View Helper](view-helper.md) | established | 1,467 | A template-based view, such as a JSP page, is easy to fill with embedded processing logic simply because the logic and the markup live in the same file, and once that happens, the ... |
 

--- a/patterns/06-enterprise-application-architecture/context-object.md
+++ b/patterns/06-enterprise-application-architecture/context-object.md
@@ -70,14 +70,22 @@ Strategies," and "General Context Object Strategies."
 ## 6. ASCII structure diagram
 
 ```
-  +----------------------+     +----------------+     +------------------+
-  | protocol-specific       | --> | Context Object   | --> | application       |
-  | object, e.g. HTTP        |     | protocol-        |     | components and     |
-  | request                  |     | independent state |     | services            |
-  +----------------------+     +----------------+     +------------------+
++---------------------------------------------+
+| protocol-specific object, e.g. HTTP request |
++---------------------------------------------+
+           v
++----------------------------+
+| Context Object             |
+| protocol-independent state |
++----------------------------+
+           v
++-------------------------------------+
+| application components and services |
++-------------------------------------+
 
-  a component only ever reads from the context object, never the
-  protocol-specific object directly, per dimension 5
+A component only ever reads from the context object,
+never the protocol-specific object directly, per
+dimension 5.
 ```
 
 ## 7. Dynamics

--- a/patterns/06-enterprise-application-architecture/metadata-mapping.md
+++ b/patterns/06-enterprise-application-architecture/metadata-mapping.md
@@ -261,38 +261,40 @@ concerns into the domain layer.
 ## 6. ASCII structure diagram
 
 ```
-+-------------------+          reads           +--------------------+
-|   Domain Class     |<------------------------ |   Mapping Engine    |
-|   (Customer)        |    populates fields via  |  (generic, one per  |
-|                     |    reflection/accessors  |   application)      |
-+-------------------+                            +----------+---------+
-                                                              |
-                                                              | consults
-                                                              v
-                                                   +----------------------+
-                                                   |      Metadata        |
-                                                   |  class -> table      |
-                                                   |  field -> column     |
-                                                   |  assoc -> FK / join  |
-                                                   +----------+-----------+
-                                                              ^
-                                                              | parses at startup
-                                                              |
-                                                   +----------------------+
-                                                   |   Metadata Loader     |
-                                                   |  (XML / annotations / |
-                                                   |   fluent config)      |
-                                                   +----------------------+
++-------------------------------------+
+| Metadata Loader                     |
+| (XML / annotations / fluent config) |
++-------------------------------------+
+           |
+           | parses at startup
+           v
++--------------------+
+| Metadata           |
+| class -> table     |
+| field -> column    |
+| assoc -> FK / join |
++--------------------+
+           ^
+           | consults
+           |
++--------------------------------+
+| Mapping Engine                 |
+| (generic, one per application) |
++--------------------------------+
+           |
+           | reads, populates fields via
+           | reflection/accessors
+           v
++-------------------------+
+| Domain Class (Customer) |
++-------------------------+
 
-                                                   +----------------------+
-                                                   |   Relational Schema   |
-                                                   |   (tables, columns,   |
-                                                   |    FKs)               |
-                                                   +----------+-----------+
-                                                              ^
-                                                              | executes SQL against
-                                                              |
-                                                       (Mapping Engine, above)
++------------------------------------------+
+| Relational Schema (tables, columns, FKs) |
++------------------------------------------+
+
+The Mapping Engine executes SQL against the Relational
+Schema above to load and save Domain Class instances.
 ```
 
 ## 7. Dynamics

--- a/patterns/07-integration/README.md
+++ b/patterns/07-integration/README.md
@@ -2,7 +2,7 @@
 
 Origin. Hohpe and Woolf
 
-54 entries, 385,782 words. Every entry carries all 18
+54 entries, 385,715 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Enterprise Integration
@@ -47,7 +47,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Command Message](command-message.md) | canonical | 6,014 | An application wants another application, or another component in the same system, to perform a specific piece of work. |
 | [Content Enricher](content-enricher.md) | canonical | 6,840 | A message arrives at an integration point carrying less data than the next step needs. |
 | [Content Filter](content-filter.md) | canonical | 8,464 | A consumer receives a message that is far larger, richer, or more deeply nested than anything it needs, and forwarding or storing that full message creates real cost. |
-| [Correlation Identifier](correlation-identifier.md) | canonical | 7,467 | A process sends a message and does not receive its answer over the same connection it used to send it. |
+| [Correlation Identifier](correlation-identifier.md) | canonical | 7,422 | A process sends a message and does not receive its answer over the same connection it used to send it. |
 | [Document Message](document-message.md) | canonical | 7,017 | Two systems need to exchange a structured record, such as a customer record, a purchase order, a lab result, or a shipment manifest. |
 | [Dynamic Router](dynamic-router.md) | canonical | 7,649 | A message-routing component in a system needs to send a message onward, and the set of places it might send that message to is not fixed at the time the router is built, deployed ... |
 | [Event Message](event-message.md) | canonical | 7,035 | An application performs an action that other applications, possibly ones the first application has never heard of and will never know about, need to react to. |
@@ -62,7 +62,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Message Sequence](message-sequence.md) | canonical | 6,955 | A producer has one logical unit of data to move across a messaging channel, and the unit is larger than the channel, the broker, or the receiving application can accept as a ... |
 | [Messaging Gateway](messaging-gateway.md) | canonical | 7,408 | An application needs to send and receive messages through a messaging system, a message queue, an event bus, a Kafka topic, an AMQP exchange, but the team does not want every part ... |
 | [Normalizer](normalizer.md) | canonical | 6,910 | A system receives messages that all describe the same real-world fact, an order was placed, a patient was admitted, a trade was executed, but the messages arrive in several ... |
-| [Routing Slip](routing-slip.md) | canonical | 7,757 | A message needs to pass through a chain of processing steps, and the exact membership and order of that chain differs per message, per tenant, or per business rule, rather than ... |
+| [Routing Slip](routing-slip.md) | canonical | 7,727 | A message needs to pass through a chain of processing steps, and the exact membership and order of that chain differs per message, per tenant, or per business rule, rather than ... |
 
 ## Integration (Message Routing)
 
@@ -93,7 +93,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
 | [Competing Consumers](competing-consumers.md) | canonical | 6,366 | A producer or a set of producers places units of work onto a channel faster, or in bursts faster, than a single consumer can process them. |
-| [Content-Based Router](content-based-router.md) | canonical | 6,816 | A single logical message stream must be handled by more than one downstream consumer, and which consumer handles a given message depends on data inside that message, not on which ... |
+| [Content-Based Router](content-based-router.md) | canonical | 6,824 | A single logical message stream must be handled by more than one downstream consumer, and which consumer handles a given message depends on data inside that message, not on which ... |
 | [Durable Subscriber](durable-subscriber.md) | canonical | 6,834 | A publisher broadcasts events on a topic. |
 | [Guaranteed Delivery](guaranteed-delivery.md) | canonical | 6,068 | A service publishes an event or sends a command onto a channel and then proceeds as if the message is on its way. |
 | [Recipient List](recipient-list.md) | canonical | 7,463 | A single message must reach more than one downstream consumer at once, and the exact SET of consumers that should receive a given message is not fixed at design time. |

--- a/patterns/07-integration/content-based-router.md
+++ b/patterns/07-integration/content-based-router.md
@@ -215,24 +215,28 @@ useful part.
 ## 6. ASCII structure diagram
 
 ```
-                          +---------------------------+
-                          |   Content-Based Router     |
-                          |-----------------------------|
-    +----------+          | rule 1: type == "domestic" |         +-------------+
-    | Producer | -------> | rule 2: type == "intl"     | ------> | Domestic Svc|
-    +----------+  inbound | rule N: (default)          |  \      +-------------+
-                 channel  +---------------------------+   \
-                                                             \     +-------------+
-                                                              ---> | Intl Svc    |
-                                                                    +-------------+
-                                                             \
-                                                              \    +-------------+
-                                                               --> | Default /   |
-                                                                    | Dead-letter |
-                                                                    +-------------+
++----------+
+| Producer |
++----------+
+     | inbound channel
+     v
++----------------------------+
+| Content-Based Router       |
+| rule 1: type == "domestic" |
+| rule 2: type == "intl"     |
+| rule N: (default)          |
++----------------------------+
+     | evaluates rules, exactly one edge fires
+     +-----------------+-----------------+
+     v                 v                 v
++--------------+  +----------+  +-------------+
+| Domestic Svc |  | Intl Svc |  | Default /   |
+|              |  |          |  | Dead-letter |
++--------------+  +----------+  +-------------+
 
-   Exactly one outbound edge fires per message. Producer and consumers never
-   see each other. The router owns the rule set and every channel reference.
+Exactly one outbound edge fires per message. Producer and
+consumers never see each other. The router owns the rule
+set and every channel reference.
 ```
 
 ## 7. Dynamics

--- a/patterns/07-integration/correlation-identifier.md
+++ b/patterns/07-integration/correlation-identifier.md
@@ -236,40 +236,41 @@ Do not reach for Correlation Identifier when the situation matches one of these.
 ## 6. ASCII structure diagram
 
 ```
-+-------------+                          +-------------+
-|  Requestor  |                          |   Replier   |
-|-------------|                          |-------------|
-| generates   |   1. request msg         | receives    |
-| correlation | -----------------------> | request,    |
-| id "abc123" |   headers                | reads       |
-|             |     correlationId=abc123 | correlationId
-| stores      |                          | from headers|
-| "abc123" -> |                          |             |
-|  pending op |   2. reply msg           | copies same |
-|             | <----------------------- | correlationId
-| looks up    |   headers                | into reply  |
-| "abc123" in |     correlationId=abc123 | headers,    |
-| pending ops |                          | unchanged   |
-| table, finds|                          |             |
-| the waiting |                          |             |
-| operation   |                          |             |
-+-------------+                          +-------------+
++-----------------------------------+
+| Requestor                         |
+| generates correlation id "abc123" |
+| stores "abc123" -> pending op     |
++-----------------------------------+
+     | 1. request msg, header correlationId=abc123
+     v
++----------------------------------------------------+
+| Replier                                            |
+| receives request, reads correlationId from headers |
+| copies same correlationId into reply headers,      |
+| unchanged                                          |
++----------------------------------------------------+
+     | 2. reply msg, header correlationId=abc123
+     v
+Requestor looks up "abc123" in its pending ops table,
+finds the waiting operation.
 
-Fan-in view, several outstanding requests on one shared inbound channel
+Fan-in view, several outstanding requests on one shared
+inbound channel. Order of arrival is irrelevant. Order
+of dispatch is by id, not by time.
 
-  Requestor sends                        Shared inbound channel receives, any order
+  Requestor sends            Shared channel receives,
+                             any order
 
-  req(id=A) ----.                        .--- reply(id=B)
-  req(id=B) ----+---> [ asynchronous ]---+---- reply(id=D)
-  req(id=C) ----+---> [   transport  ]---+---- reply(id=A)
-  req(id=D) ----'                        '---- reply(id=C)
+  req(id=A) --.              .--- reply(id=B)
+  req(id=B) --+-[ async  ]--+---- reply(id=D)
+  req(id=C) --+-[transport]--+---- reply(id=A)
+  req(id=D) --'              '---- reply(id=C)
 
   Correlating consumer
     lookup(B) -> resumes op B
     lookup(D) -> resumes op D
     lookup(A) -> resumes op A
     lookup(C) -> resumes op C
-  Order of arrival is irrelevant. Order of dispatch is by id, not by time.
 ```
 
 ## 7. Dynamics

--- a/patterns/07-integration/routing-slip.md
+++ b/patterns/07-integration/routing-slip.md
@@ -250,41 +250,41 @@ serialise cleanly onto a message bus.
 ## 6. ASCII structure diagram
 
 ```
-                     +----------------------------------------+
-                     |              Message                    |
-                     |  payload: { orderId, items, ... }        |
-                     |------------------------------------------|
-                     |          Routing Slip (attached)          |
-                     |  itinerary:  [ Validate, TaxCalc,          |
-                     |                Reserve, Charge, Ship ]     |
-                     |  completed:  [ ]                          |
-                     |  variables:  { }                          |
-                     +----------------------------------------+
-                                     |
-                                     v
-   +------------------+     +------------------+     +------------------+
-   |  Router / Coord   | --> | Processing Step  | --> |  Router / Coord   |
-   |  reads itinerary  |     |  Validate         |     |  advances slip     |
-   |  hop pointer = 0  |     |  (Activity)        |     |  hop pointer = 1   |
-   +------------------+     +------------------+     +------------------+
-                                                              |
-                                                              v
-                                                     +------------------+
-                                                     | Processing Step  |
-                                                     |  TaxCalc          |
-                                                     +------------------+
-                                                              |
-                                        ... continues for Reserve, Charge, Ship ...
-                                                              |
-                                                              v
-                                                     +------------------+
-                                                     |   Finalize        |
-                                                     |  itinerary empty  |
-                                                     +------------------+
++-----------------------------------------------------+
+| Message                                             |
+| payload: orderId, items, ...                        |
+|                                                     |
+| Routing Slip (attached)                             |
+| itinerary: Validate, TaxCalc, Reserve, Charge, Ship |
+| completed: []                                       |
+| variables: {}                                       |
++-----------------------------------------------------+
+           |
+           v
++----------------------------------+
+| Router / Coordinator             |
+| reads itinerary, hop pointer = 0 |
++----------------------------------+
+           v
++--------------------------------------+
+| Processing Step: Validate (Activity) |
++--------------------------------------+
+           | router advances slip, hop pointer = 1
+           v
++--------------------------+
+| Processing Step: TaxCalc |
++--------------------------+
+           |
+           | continues for Reserve, Charge, Ship
+           v
++---------------------------+
+| Finalize, itinerary empty |
++---------------------------+
 
-  Each box the message visits is generic. it knows only how to read
-  the slip's current hop and how to hand the message to whatever the
-  slip names as the next one. No box hardcodes any other box's name.
+Each box the message visits is generic. It knows only how
+to read the slip's current hop and how to hand the
+message to whatever the slip names as the next one. No
+box hardcodes any other box's name.
 ```
 
 ## 7. Dynamics

--- a/patterns/08-cloud-distributed/README.md
+++ b/patterns/08-cloud-distributed/README.md
@@ -2,7 +2,7 @@
 
 Origin. Azure Architecture Center, Nygard
 
-44 entries, 393,160 words. Every entry carries all 18
+44 entries, 393,044 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Capacity Management
@@ -24,7 +24,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
-| [External Configuration Store](external-configuration-store.md) | canonical | 8,367 | An application reads its behavior-controlling values, a database connection string, a feature toggle, a rate limit, a UI theme choice, a downstream service URL, from a file that ... |
+| [External Configuration Store](external-configuration-store.md) | canonical | 8,251 | An application reads its behavior-controlling values, a database connection string, a feature toggle, a rate limit, a UI theme choice, a downstream service URL, from a file that ... |
 
 ## Cloud and Distributed
 

--- a/patterns/08-cloud-distributed/external-configuration-store.md
+++ b/patterns/08-cloud-distributed/external-configuration-store.md
@@ -273,44 +273,40 @@ Problems and considerations, verified 2026-08-03).
 ## 6. ASCII structure diagram
 
 ```
-                        +------------------------------+
-                        |  External Configuration Store |
-                        |  (Azure App Config / AWS      |
-                        |   AppConfig / etcd / Consul /  |
-                        |   Spring Cloud Config server)  |
-                        |                                |
-                        |  key  rate.limit.checkout      |
-                        |  val  500                      |
-                        |  ver  42     label  production  |
-                        +---------------+----------------+
-                                |    ^         |    ^
-                        fetch / watch |         |    |
-                                |    | write    |    |
-              +-----------------+    +----------+    +------------------+
-              |                                                          |
-     +--------v--------+                                       +--------v--------+
-     | App instance A   |                                       | App instance B   |
-     |                  |                                       |                  |
-     |  +------------+  |                                       |  +------------+  |
-     |  | Config     |  |                                       |  | Config     |  |
-     |  | interface  |  |                                       |  | interface  |  |
-     |  +-----+------+  |                                       |  +-----+------+  |
-     |        |         |                                       |        |         |
-     |  +-----v------+  |                                       |  +-----v------+  |
-     |  | Local cache|  |                                       |  | Local cache|  |
-     |  +-----+------+  |                                       |  +-----+------+  |
-     |        |         |                                       |        |         |
-     |  +-----v------+  |                                       |  +-----v------+  |
-     |  | Fallback   |  |                                       |  | Fallback   |  |
-     |  | (baked in  |  |                                       |  | (baked in  |  |
-     |  |  artifact) |  |                                       |  |  artifact) |  |
-     |  +------------+  |                                       |  +------------+  |
-     +------------------+                                       +------------------+
++--------------------------------------+
+| External Configuration Store         |
+| (Azure App Config / AWS AppConfig /  |
+| etcd / Consul / Spring Cloud Config) |
+|                                      |
+| key  rate.limit.checkout             |
+| val  500                             |
+| ver  42     label  production        |
++--------------------------------------+
+           ^  |
+     write |  | fetch / watch
+           |  v
+     +-----+--+-----+
+     |               |
+(App instance A)  (App instance B, identical shape)
 
-        A and B are two instances of the SAME application, or two
-        DIFFERENT applications sharing one setting. Both read the
-        same key from the same store, so both converge on the same
-        value once each cache refreshes.
++------------------+
+| Config interface |
++------------------+
+           |
+           v
++-------------+
+| Local cache |
++-------------+
+           |
+           v
++------------------------------+
+| Fallback (baked in artifact) |
++------------------------------+
+
+Each app instance independently fetches from and
+watches the store, reads through its local cache, and
+falls back to its baked-in artifact if the store is
+unreachable.
 ```
 
 ## 7. Dynamics

--- a/patterns/11-domain-driven-design/README.md
+++ b/patterns/11-domain-driven-design/README.md
@@ -2,7 +2,7 @@
 
 Origin. Evans, Vernon
 
-35 entries, 264,770 words. Every entry carries all 18
+35 entries, 264,744 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Anti-pattern
@@ -65,13 +65,13 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Bounded Context](bounded-context.md) | canonical | 6,827 | A software system of any real size accumulates more than one team, more than one department's worldview, and more than one legitimate meaning for the same word. |
 | [Conformist](conformist.md) | canonical | 6,538 | Two bounded contexts need to exchange data or invoke each other's behaviour, and one of the two, the upstream, owns a model neither side is free to renegotiate. |
 | [Context Canvas](context-canvas.md) | established | 7,622 | A team has decided, usually from an Event Storming session or from a Context Map already in hand, that a particular slice of the domain deserves its own bounded context. |
-| [Context Map](context-map.md) | canonical | 7,312 | A system reaches a certain size and a certain number of contributing teams before a single, internally consistent domain model stops being achievable. |
+| [Context Map](context-map.md) | canonical | 7,294 | A system reaches a certain size and a certain number of contributing teams before a single, internally consistent domain model stops being achievable. |
 | [Core Domain](core-domain.md) | canonical | 6,670 | A team building a non-trivial system faces a resource allocation problem long before it faces a technical one. |
 | [Customer-Supplier](customer-supplier.md) | canonical | 7,914 | Any system large enough to be split across more than one Bounded Context, see the bounded-context entry in this repository, produces integration points where one context's model ... |
 | [Open Host Service](open-host-service.md) | canonical | 9,358 | A bounded context that has real internal complexity attracts multiple downstream consumers over time. |
 | [Partnership](partnership.md) | canonical | 7,024 | Two teams each own a Bounded Context, and the two Contexts must integrate, but neither team can honestly claim to be upstream of the other. |
 | [Separate Ways](separate-ways.md) | canonical | 9,250 | A team splits a system into more than one Bounded Context for good reasons, because two departments' vocabularies genuinely diverge, because two teams cannot coordinate closely ... |
-| [Shared Kernel](shared-kernel.md) | canonical | 7,408 | Two Bounded Contexts model a piece of the domain in a compatible way, not because either team designed it that way on purpose, but because the concept genuinely is the same ... |
+| [Shared Kernel](shared-kernel.md) | canonical | 7,403 | Two Bounded Contexts model a piece of the domain in a compatible way, not because either team designed it that way on purpose, but because the concept genuinely is the same ... |
 | [Subdomain Discovery](subdomain-discovery.md) | established | 7,371 | A team about to build or re-architect a nontrivial system faces a boundary problem before it faces a single line of code. |
 | [Supporting Subdomain](supporting-subdomain.md) | canonical | 6,681 | A team building a system of real size eventually owns far more functionality than any one part of the business actually differentiates on. |
 
@@ -97,7 +97,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
-| [Domain Primitive](domain-primitive.md) | canonical | 7,263 | A codebase accretes validation logic at the edges and loses track of where the truth lives. |
+| [Domain Primitive](domain-primitive.md) | canonical | 7,260 | A codebase accretes validation logic at the edges and loses track of where the truth lives. |
 | [Entity](entity.md) | canonical | 7,973 | Every large domain contains two very different kinds of things, and conflating them is one of the most common sources of subtle correctness bugs in business software. |
 
 ## Reading order

--- a/patterns/11-domain-driven-design/context-map.md
+++ b/patterns/11-domain-driven-design/context-map.md
@@ -244,34 +244,47 @@ Map figures.
 ## 6. ASCII structure diagram
 
 ```
-+-----------------------------+          U/D          +---------------------+
-|   Billing Context           |----------------------->|  Payment Gateway    |
-|   (Sales subdomain)         |   Conformist            |  (third-party,     |
-|                              |   D: no negotiation     |   upstream)         |
-+---------------+--------------+                        +---------------------+
-                |
-                | Anticorruption Layer
-                | D: Billing owns translation
-                v
-+-----------------------------+   Open Host Service     +---------------------+
-|   Support Context           |<------------------------|  Published Lang.    |
-|   (Support subdomain)       |   U: exposes stable API |  (shared JSON       |
-|                              |   contract               |  ticket schema)     |
-+---------------+--------------+                        +---------------------+
-                |
-                | Shared Kernel
-                | (jointly owned "Account" module)
-                v
-+-----------------------------+                        +---------------------+
-|   Identity Context           |<----------------------|  Legacy Order System |
-|   (Core subdomain)           |   Conformist            |  (upstream, no      |
-|                               |   D: no negotiation     |   negotiation)      |
-+-------------------------------+                        +---------------------+
++-----------------------------------+
+| Billing Context (Sales subdomain) |
++-----------------------------------+
+           | Conformist, U/D, D: no negotiation
+           v
++-----------------------------------------+
+| Payment Gateway (third-party, upstream) |
++-----------------------------------------+
 
-+-----------------------------+          Separate Ways          +----------------+
-|   Marketing Analytics        |<--------------------------------|  Support        |
-|   (no integration needed)    |          no connection drawn    |  Context        |
-+-----------------------------+                                  +----------------+
++-------------------------------------+
+| Support Context (Support subdomain) |
++-------------------------------------+
+           ^
+           | Open Host Service, U: exposes stable
+           | API contract
++---------------------------------------------+
+| Published Lang. (shared JSON ticket schema) |
++---------------------------------------------+
+
+Billing -> Support: Anticorruption Layer, D: Billing
+owns translation.
+
++-----------------------------------+
+| Identity Context (Core subdomain) |
++-----------------------------------+
+           ^
+           | Conformist, D: no negotiation
++------------------------------------------------+
+| Legacy Order System (upstream, no negotiation) |
++------------------------------------------------+
+
+Support -> Identity: Shared Kernel (jointly owned
+"Account" module).
+
++---------------------------------------------+
+| Marketing Analytics (no integration needed) |
++---------------------------------------------+
+           . Separate Ways, no connection drawn
++-----------------+
+| Support Context |
++-----------------+
 ```
 
 ## 7. Dynamics

--- a/patterns/11-domain-driven-design/domain-primitive.md
+++ b/patterns/11-domain-driven-design/domain-primitive.md
@@ -251,36 +251,38 @@ the more important half of the dimension and the one most catalogs skip.
 ## 6. ASCII structure diagram
 
 ```
-                     +-----------------------------+
-                     |  Domain Primitive             |
-                     |  (e.g. EmailAddress)          |
-                     +-------------------------------+
-                     | - value: String  (private)    |
-                     +-------------------------------+
-                     | + of(raw: String): Result      |<-- validates, never throws
-                     | + toString(): String            |     across a trust boundary
-                     | + equals(other): boolean         |
-                     | + hashCode(): int                 |
-                     +-------------------------------+
-                              ^ constructed by
-                              |
-        +---------------------+---------------------+
-        |                                             |
-+---------------+                          +----------------------+
-| Boundary       |  raw String, int, etc.  | Validation rule set   |
-| translator     |------------------------->| (inline or delegated |
-| (controller,   |                          |  to a Specification) |
-| deserializer)  |                          +----------------------+
-+---------------+
-        |
-        | constructs, on success
-        v
++--------------------------------------+
+| Domain Primitive (e.g. EmailAddress) |
+| value: String  (private)             |
+| of(raw: String): Result              |
+| toString(): String                   |
+| equals(other): boolean               |
+| hashCode(): int                      |
++--------------------------------------+
+(of() validates, never throws across a trust boundary)
+           ^ constructed by
+           |
+     +-----+-----+
+     |           |
++---------------------+ +---------------------+
+| Boundary translator | | Validation rule set |
+| (controller,        | | (inline or delegated|
+| deserializer)       | | to a Specification) |
++---------------------+ +---------------------+
+
+(raw String, int, etc. flows from translator into
+the rule set)
+
+     |
+     | constructs, on success
+     v
 +----------------------------------------------+
-| Consumer (application service, Entity field,  |
-| another Domain Primitive)                     |
+| Consumer (application service, Entity field, |
+| another Domain Primitive)                    |
 +----------------------------------------------+
-        never receives the raw, unvalidated
-        primitive once this boundary is crossed
+
+Never receives the raw, unvalidated primitive once
+this boundary is crossed.
 ```
 
 ## 7. Dynamics

--- a/patterns/11-domain-driven-design/saga-versus-process-manager.md
+++ b/patterns/11-domain-driven-design/saga-versus-process-manager.md
@@ -304,38 +304,51 @@ skip:
 ```
 CHOREOGRAPHY (no Process Manager, no central object)
 
-   +-------------+  OrderCreated   +-------------+  PaymentCharged  +-------------+
-   |    Order    | -------------> |   Payment   | --------------> |  Inventory  |
-   |   Service   |                |   Service   |                 |   Service   |
-   +-------------+                +-------------+                 +-------------+
-         ^                              |                                |
-         | PaymentFailed                | InventoryReservationFailed     |
-         +------------------------------+--------------------------------+
-   No single object holds the whole flow. Each arrow is a pub/sub event.
++---------------+
+| Order Service |
++---------------+
+           | OrderCreated
+           v
++-----------------+
+| Payment Service |
++-----------------+
+           | PaymentCharged
+           v
++-------------------+
+| Inventory Service |
++-------------------+
+
+Failure paths, each its own pub/sub event:
+  Payment Service --PaymentFailed--> Order Service
+  Inventory Service --InventoryReservationFailed-->
+  Order Service
+
+No single object holds the whole flow. Each arrow
+is a pub/sub event.
 
 
-ORCHESTRATION (a Process Manager coordinates the same steps)
+ORCHESTRATION (a Process Manager coordinates the
+same steps)
 
-                          +----------------------------+
-                          |   Order Saga Orchestrator   |
-                          |  (a Process Manager)        |
-                          |  state = AWAITING_PAYMENT   |
-                          +----------------------------+
-                             |  command        ^ reply
-                             v                 |
-                          +-------------+
-                          |   Payment   |
-                          |   Service   |
-                          +-------------+
-                             |  command        ^ reply
-                             v                 |
-                          +-------------+
-                          |  Inventory  |
-                          |   Service   |
-                          +-------------+
++--------------------------+
+| Order Saga Orchestrator  |
+| (a Process Manager)      |
+| state = AWAITING_PAYMENT |
++--------------------------+
+           | command      ^ reply
+           v              |
++-----------------+
+| Payment Service |
++-----------------+
+           | command      ^ reply
+           v              |
++-------------------+
+| Inventory Service |
++-------------------+
 
-   The orchestrator sends one command at a time and owns the whole
-   sequence. Participants know only the orchestrator, not each other.
+The orchestrator sends one command at a time and
+owns the whole sequence. Participants know only the
+orchestrator, not each other.
 ```
 
 ## 7. Dynamics

--- a/patterns/11-domain-driven-design/shared-kernel.md
+++ b/patterns/11-domain-driven-design/shared-kernel.md
@@ -244,29 +244,30 @@ depends on.
 ## 6. ASCII structure diagram
 
 ```
-+-----------------------------+          +-----------------------------+
-|   Bounded Context. Billing  |          | Bounded Context. Fulfillment|
-|   (owned by Team Billing)   |          | (owned by Team Fulfillment) |
-|                              |          |                              |
-|  Invoice, Payment,           |          |  Shipment, Route,            |
-|  BillingAccount               |          |  DeliveryWindow              |
-+---------------+---------------+          +---------------+---------------+
-                |                                            |
-                | imports / depends on                       | imports / depends on
-                v                                            v
-        +-------------------------------------------------------+
-        |                     SHARED KERNEL                     |
-        |  Money (currency, amount, rounding rule)               |
-        |  OrderId (identifier type, equality, parsing)          |
-        |  ShipmentRequested (domain event, field shape)         |
-        +-------------------------------------------------------+
-                                    |
-                                    | governed by
-                                    v
-                +---------------------------------------+
-                |  Joint review + shared CI + version tag |
-                |  (both teams sign off, both teams test) |
-                +---------------------------------------+
++------------------------------+ +------------------------------+
+| Bounded Context: Billing     | | Bounded Context: Fulfillment |
+| (owned by Team Billing)      | | (owned by Team Fulfillment)  |
+|                              | |                              |
+| Invoice, Payment,            | | Shipment, Route,             |
+| BillingAccount               | | DeliveryWindow               |
++------------------------------+ +------------------------------+
+     |                          |
+     +-----------+--------------+
+         imports / depends on
+                 v
++-----------------------------------------------+
+| SHARED KERNEL                                 |
+| Money (currency, amount, rounding rule)       |
+| OrderId (identifier type, equality, parsing)  |
+| ShipmentRequested (domain event, field shape) |
++-----------------------------------------------+
+                 |
+                 | governed by
+                 v
++----------------------------------------+
+| Joint review + shared CI + version tag |
+| (both teams sign off, both teams test) |
++----------------------------------------+
 ```
 
 The kernel sits below both contexts, not beside them, because it is a

--- a/patterns/12-data-storage/README.md
+++ b/patterns/12-data-storage/README.md
@@ -2,7 +2,7 @@
 
 Origin. Kleppmann
 
-45 entries, 319,830 words. Every entry carries all 18
+45 entries, 319,818 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Concurrency Control
@@ -48,13 +48,13 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [LSM Tree](lsm-tree.md) | canonical | 9,064 | A key-value or wide-column store needs to sustain a high rate of writes, including writes that touch keys scattered across the entire key space, while still answering point ... |
 | [Lamport Clock](lamport-clock.md) | canonical | 6,460 | A distributed system has no shared memory and no shared clock. |
 | [Leaderless Replication](leaderless-replication.md) | canonical | 7,925 | A single-leader replicated database routes every write through one node. |
-| [Log Compaction](log-compaction.md) | established | 8,043 | An append-only log is the simplest and most dependable storage primitive a distributed system offers. |
+| [Log Compaction](log-compaction.md) | established | 8,019 | An append-only log is the simplest and most dependable storage primitive a distributed system offers. |
 | [Medallion Architecture](medallion-architecture.md) | established | 7,094 | A data platform ingests information from many upstream systems. |
 | [Multi-Leader Replication](multi-leader-replication.md) | established | 7,906 | A team runs a database that serves write traffic from more than one geographic region, or from more than one autonomous system that must keep working during a network partition ... |
 | [Multiversion Concurrency Control](mvcc.md) | canonical | 7,230 | A database serves many concurrent transactions. |
 | [Quorum](quorum.md) | canonical | 7,448 | A system replicates the same piece of data onto several nodes so that the loss of any one node, or the temporary unavailability of any one node, does not lose data or stop the ... |
 | [Read Repair](read-repair.md) | canonical | 6,416 | A system with leaderless, quorum-based replication accepts writes on any of several replicas for a key, and a temporarily unreachable replica, a dropped message, or a slow node ... |
-| [Read-Through Cache](read-through-cache.md) | canonical | 7,970 | An application reads the same piece of data far more often than the data changes. |
+| [Read-Through Cache](read-through-cache.md) | canonical | 7,982 | An application reads the same piece of data far more often than the data changes. |
 | [Slowly Changing Dimensions](slowly-changing-dimensions.md) | canonical | 7,737 | A dimensional data warehouse separates numeric, frequently-recorded facts (an order line, a sensor reading, a page view) from the descriptive dimensions those facts are analyzed ... |
 | [Snowflake Schema](snowflake-schema.md) | canonical | 7,439 | A team building a data warehouse or a semantic model for business intelligence needs to answer analytical questions fast, total revenue by region and month, units sold by product ... |
 | [Star Schema](star-schema.md) | canonical | 7,771 | An organization accumulates a large volume of business events, orders, shipments, page views, sensor readings, trades. |

--- a/patterns/12-data-storage/log-compaction.md
+++ b/patterns/12-data-storage/log-compaction.md
@@ -236,36 +236,42 @@ avoid the fixed overhead of a compaction pass for marginal space savings.
 ## 6. ASCII structure diagram
 
 ```
-                              PARTITION (single log)
-  +------------------------------------------------------------------+
-  |  TAIL (compacted, <=1 record/key)  |  HEAD (dirty, duplicates ok) |
-  |  segment.0   segment.1  segment.2  |   segment.3     segment.4    |
-  |  [k1=v1]     [k3=v2]    [k2=v3]    |   [k1=v4][k3=T] [k4=v5][k1=v6]|
-  +------------------------------------------------------------------+
-        ^ closed, immutable                    ^ segment.4 = active
-        |                                       | (still being appended)
-        |                                       |
-        +---- log cleaner reads dirty segments --+
-              builds offset map, key to highest offset
-              rewrites tail with duplicates dropped, tombstones kept
-              (tombstones dropped only after delete.retention.ms elapses)
+PARTITION (single log)
 
-  Cleaner selection loop (one pass, repeats):
+TAIL (compacted, <=1 record/key), closed, immutable
+  segment.0   segment.1   segment.2
+  [k1=v1]     [k3=v2]     [k2=v3]
 
-    for each partition P in cluster (round robin by dirty ratio):
-        dirty_ratio = bytes(head(P)) / bytes(P)
-        if dirty_ratio < min.cleanable.dirty.ratio:
-            skip P this round
-        else:
-            build_offset_map(head(P))          # key -> highest offset
-            for segment in dirty_segments(P):
-                for record in segment:
-                    if record.offset == offset_map[record.key]:
-                        keep record             # this IS the latest
-                    elif record.is_tombstone and age(record) < delete.retention.ms:
-                        keep record             # grace window
-                    else:
-                        drop record              # superseded, space freed
+HEAD (dirty, duplicates ok)
+  segment.3         segment.4 (active,
+  [k1=v4][k3=T]     still being appended)
+                    [k4=v5][k1=v6]
+
+log cleaner reads dirty segments (HEAD), then:
+  builds offset map, key to highest offset
+  rewrites TAIL with duplicates dropped,
+  tombstones kept (tombstones dropped only
+  after delete.retention.ms elapses)
+
+Cleaner selection loop (one pass, repeats):
+
+for each partition P in cluster (round robin by
+dirty ratio):
+    dirty_ratio = bytes(head(P)) / bytes(P)
+    if dirty_ratio < min.cleanable.dirty.ratio:
+        skip P this round
+    else:
+        build_offset_map(head(P))  # key -> offset
+        for segment in dirty_segments(P):
+            for record in segment:
+                if record.offset ==
+                   offset_map[record.key]:
+                    keep record  # latest
+                elif record.is_tombstone and
+                     age(record) < delete.retention.ms:
+                    keep record  # grace window
+                else:
+                    drop record  # superseded
 ```
 
 ## 7. Dynamics

--- a/patterns/12-data-storage/read-through-cache.md
+++ b/patterns/12-data-storage/read-through-cache.md
@@ -254,25 +254,37 @@ depends on both the Cache and the Origin and coordinates between them itself.
 ## 6. ASCII structure diagram
 
 ```
-      +-------------+          +---------------------+          +-----------+
-      |   Client    |  get(k)  |        Cache         |  load(k) |  Loader   |
-      |-------------|--------->|----------------------|--------->|-----------|
-      | (no origin  |          | map<K,V> store        |          | fetch(K):V|
-      |  dependency)|<---------| eviction policy (TTL, |<---------|           |
-      +-------------+  value   | size bound)           |  value   +-----------+
-                                +----------+-----------+                |
-                                           ^                            | query
-                                           |                            v
-                                     (cache hit path,               +-----------+
-                                      no Loader call)                |  Origin   |
-                                                                      | database, |
-                                                                      | API, or   |
-                                                                      | expensive |
-                                                                      | compute   |
-                                                                      +-----------+
++-------------------------------+
+| Client (no origin dependency) |
++-------------------------------+
+           | get(k)
+           v
++-----------------------------------+
+| Cache                             |
+| map<K,V> store                    |
+| eviction policy (TTL, size bound) |
++-----------------------------------+
+           | value, returned to Client above
+           |
+           | load(k), only on a cache miss
+           v
++-------------+
+| Loader      |
+| fetch(K): V |
++-------------+
+           | value, returned to Cache above
+           |
+           | query
+           v
++-------------------------------------+
+| Origin                              |
+| database, API, or expensive compute |
++-------------------------------------+
 
-   The Client's only compile time dependency is Cache. Origin is reachable
-   only through Loader, which the Cache owns and calls, never the Client.
+A cache hit answers from the Cache directly, no Loader
+call. The Client's only compile-time dependency is
+Cache. Origin is reachable only through Loader, which
+the Cache owns and calls, never the Client.
 ```
 
 ## 7. Dynamics

--- a/patterns/14-testing/README.md
+++ b/patterns/14-testing/README.md
@@ -2,14 +2,14 @@
 
 Origin. Meszaros, xUnit Test Patterns
 
-30 entries, 217,027 words. Every entry carries all 18
+30 entries, 217,017 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Test Data
 
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
-| [Derived Value](derived-value.md) | canonical | 5,157 | A test needs data. Every object under test, and every collaborator it talks to, has fields that must be filled in before the test can run, and the overwhelming majority of those ... |
+| [Derived Value](derived-value.md) | canonical | 5,147 | A test needs data. Every object under test, and every collaborator it talks to, has fields that must be filled in before the test can run, and the overwhelming majority of those ... |
 | [Generated Value](generated-value.md) | canonical | 6,233 | A fixture object almost always has more fields than the test actually cares about. |
 
 ## Test Double

--- a/patterns/14-testing/derived-value.md
+++ b/patterns/14-testing/derived-value.md
@@ -163,20 +163,27 @@ never need to know, and should not depend on, how the value was produced.
 ## 6. ASCII structure diagram
 
 ```
-+---------------------+     +------------------------+     +----------------+
-|        Seed          |     |   Derivation Function   |     | Derived Value  |
-|-----------------------|---->|--------------------------|---->|----------------|
-| counter, test name,   |     | prefix + seed            |     | "user-0007"    |
-| or a sibling field     |     | hash(seed) mod range      |     | (unique, or    |
-|                        |     | slugify(title)            |     |  consistent    |
-+---------------------+     +------------------------+     |  with sibling) |
-                                                             +----------------+
-                                                                     |
-                                                                     v
-                                                             +----------------+
-                                                             | Fixture Object |
-                                                             | under test     |
-                                                             +----------------+
++---------------------+
+| Seed                |
+| counter, test name, |
+| or a sibling field  |
++---------------------+
+           v
++----------------------+
+| Derivation Function  |
+| prefix + seed        |
+| hash(seed) mod range |
+| slugify(title)       |
++----------------------+
+           v
++--------------------------------------+
+| Derived Value: "user-0007"           |
+| (unique, or consistent with sibling) |
++--------------------------------------+
+           v
++---------------------------+
+| Fixture Object under test |
++---------------------------+
 ```
 
 ## 7. Dynamics


### PR DESCRIPTION
## Summary

- Redraws ten more ASCII diagrams that exceeded 78 characters wide, the
  next tier at 82 to 83 characters, down to 45 to 64 characters.
- feature-envy.md, introduce-assertion.md, preserve-whole-object.md,
  polymorphism.md, single-responsibility-principle.md,
  serverless-architecture.md, content-based-router.md,
  correlation-identifier.md, routing-slip.md, message-chains.md.
- No structural, prose, reference, or code content changed. Only the
  diagram fences.
- tools/gen-indexes.py was re-run before this commit, regenerating the
  four family index tables these entries span.

## Notable redesigns

- introduce-assertion.md and preserve-whole-object.md were a two
  column BEFORE and AFTER code snippet. Both became a stacked BEFORE
  section followed by an AFTER section.
- polymorphism.md's Client, Abstraction, and three concrete
  implementations were one wide graph. It is now a vertical chain into
  the Abstraction, with the three implementations stacked below it.
- single-responsibility-principle.md's after state, three
  collaborators each reading the same Invoice, is now the Invoice box
  on top with the three reader boxes in a row beneath it, each still
  carrying its own actor annotation.
- content-based-router.md's three outbound branches (Domestic, Intl,
  Default or Dead-letter) are drawn as a fan from the router into a
  row of three boxes rather than three long diagonal arrows.

## Test plan

- [x] check-structure.py, 884 of 884 entries pass
- [x] check-prose.py, 925 of 925 entries pass
- [x] markdownlint-cli2 0.23.2, 0 issues on the ten changed files
- [x] validate-refs.py --strict, every citation resolves
- [x] check-code.py --strict, 2826 compiled, 0 failed, 0 skipped
- [x] gen-indexes.py re-run, four family README tables regenerated and
      committed alongside the content changes
- [x] git diff --stat -- docs and dist and the root README.md, all
      empty, no unexpected top level changes

57 more entries with the same width issue remain, to be worked through
in following batches.
