### PR TITLE
fix(patterns) redraw ten more ASCII diagrams under 78 columns

### DIFF
--- a/patterns/03-refactoring/encapsulate-record.md
+++ b/patterns/03-refactoring/encapsulate-record.md
@@ -140,29 +140,45 @@ The refactoring has one participant.
 ## 6. ASCII structure diagram
 
 ```
-  BEFORE                                  AFTER
-  ------                                  -----
+BEFORE
+------
 
-  record ConnectionConfig:                class ConnectionConfig:
-    host: str                               _host: str   (private)
-    port: int                               _port: int   (private)
-    timeout: int                            _timeout: int (private)
-    retryCount: int                         _retry: int   (private)
+record ConnectionConfig:
+  host: str
+  port: int
+  timeout: int
+  retryCount: int
 
-  caller:                                 constructor(host, port, timeout, retry):
-    config = ConnectionConfig()                if not (1 <= port <= 65535):
-    config.host = "db.example"                     raise ValueError("port")
-    config.port = 0                           if timeout < 0:
-    config.timeout = -1                           raise ValueError("timeout")
-                                              ...
+caller:
+  config = ConnectionConfig()
+  config.host = "db.example"
+  config.port = 0
+  config.timeout = -1
 
-                                          getPort(): int
-                                              return _port
 
-                                          setPort(port):
-                                              if not (1 <= port <= 65535):
-                                                  raise ValueError
-                                              _port = port
+AFTER
+-----
+
+class ConnectionConfig:
+  _host: str      (private)
+  _port: int      (private)
+  _timeout: int   (private)
+  _retry: int     (private)
+
+constructor(host, port, timeout, retry):
+  if not (1 <= port <= 65535):
+    raise ValueError("port")
+  if timeout < 0:
+    raise ValueError("timeout")
+  ...
+
+getPort(): int
+  return _port
+
+setPort(port):
+  if not (1 <= port <= 65535):
+    raise ValueError
+  _port = port
 ```
 
 ## 7. Dynamics

--- a/patterns/04-principles-and-laws/README.md
+++ b/patterns/04-principles-and-laws/README.md
@@ -2,7 +2,7 @@
 
 Origin. Martin, Larman, Brewer, Conway
 
-42 entries, 327,241 words. Every entry carries all 18
+42 entries, 327,228 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Design Principle
@@ -30,7 +30,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [ACID](acid.md) | canonical | 7,029 | A database serves many concurrent operations against shared, durable state. |
 | [BASE](base.md) | canonical | 8,219 | A system holds one logical piece of data on more than one physical machine, because a single machine cannot serve the read and write volume, cannot survive its own failure, or ... |
 | [CAP Theorem](cap-theorem.md) | canonical | 7,623 | A system holds one piece of mutable state that more than one machine can read and write, and those machines are connected by a network that is not perfectly reliable. |
-| [Common Closure Principle](common-closure-principle.md) | canonical | 7,574 | A codebase reaches the size where a single flat namespace of classes stops being a unit anyone can reason about, and the team splits it into smaller compilation and deployment ... |
+| [Common Closure Principle](common-closure-principle.md) | canonical | 7,561 | A codebase reaches the size where a single flat namespace of classes stops being a unit anyone can reason about, and the team splits it into smaller compilation and deployment ... |
 | [Composition over Inheritance](composition-over-inheritance.md) | canonical | 6,930 | A designer needs an object to have several independent, combinable behaviours, and reaches for a single class hierarchy to express all of them. |
 | [Controller](controller.md) | canonical | 6,874 | A team wiring a new interaction into an object-oriented system reaches a concrete, recurring question the moment a user clicks a button, submits a form, or an external system ... |
 | [Conway's Law](conway-law.md) | canonical | 7,751 | A team is asked to build a system with several distinct concerns. |

--- a/patterns/04-principles-and-laws/README.md
+++ b/patterns/04-principles-and-laws/README.md
@@ -2,7 +2,7 @@
 
 Origin. Martin, Larman, Brewer, Conway
 
-42 entries, 327,261 words. Every entry carries all 18
+42 entries, 327,248 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Design Principle
@@ -30,7 +30,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [ACID](acid.md) | canonical | 7,029 | A database serves many concurrent operations against shared, durable state. |
 | [BASE](base.md) | canonical | 8,219 | A system holds one logical piece of data on more than one physical machine, because a single machine cannot serve the read and write volume, cannot survive its own failure, or ... |
 | [CAP Theorem](cap-theorem.md) | canonical | 7,623 | A system holds one piece of mutable state that more than one machine can read and write, and those machines are connected by a network that is not perfectly reliable. |
-| [Common Closure Principle](common-closure-principle.md) | canonical | 7,574 | A codebase reaches the size where a single flat namespace of classes stops being a unit anyone can reason about, and the team splits it into smaller compilation and deployment ... |
+| [Common Closure Principle](common-closure-principle.md) | canonical | 7,561 | A codebase reaches the size where a single flat namespace of classes stops being a unit anyone can reason about, and the team splits it into smaller compilation and deployment ... |
 | [Composition over Inheritance](composition-over-inheritance.md) | canonical | 6,930 | A designer needs an object to have several independent, combinable behaviours, and reaches for a single class hierarchy to express all of them. |
 | [Controller](controller.md) | canonical | 6,874 | A team wiring a new interaction into an object-oriented system reaches a concrete, recurring question the moment a user clicks a button, submits a form, or an external system ... |
 | [Conway's Law](conway-law.md) | canonical | 7,751 | A team is asked to build a system with several distinct concerns. |

--- a/patterns/04-principles-and-laws/common-closure-principle.md
+++ b/patterns/04-principles-and-laws/common-closure-principle.md
@@ -233,31 +233,52 @@ dependency graph would reveal.
 ## 6. ASCII structure diagram
 
 ```
-BEFORE CCP: classes grouped by object type, not by reason for change
+BEFORE CCP, classes grouped by object type, not by reason
+for change
 
-  +------------------+   +------------------+   +------------------+
-  |    Entities      |   |    Services      |   |   Formatters     |
-  |------------------|   |------------------|   |------------------|
-  | Invoice          |   | TaxService       |   | TaxLineFormatter |
-  | Customer         |   | ShippingService  |   | ShipLineFormatter|
-  | ShipmentRecord   |   | DiscountService  |   | InvoicePDF       |
-  +------------------+   +------------------+   +------------------+
-         ^                       ^                       ^
-         |                       |                       |
-     a "tax rule" requirement touches all three components
++----------------+
+| Entities       |
+| Invoice        |
+| Customer       |
+| ShipmentRecord |
++----------------+
++-----------------+
+| Services        |
+| TaxService      |
+| ShippingService |
+| DiscountService |
++-----------------+
++-------------------+
+| Formatters        |
+| TaxLineFormatter  |
+| ShipLineFormatter |
+| InvoicePDF        |
++-------------------+
 
-AFTER CCP: classes grouped by axis of change
+A tax rule requirement touches all three components.
 
-  +--------------------+   +---------------------+   +---------------------+
-  |   TaxCalculation    |   |   ShippingRules      |   |   DiscountEngine    |
-  |----------------------|   |-----------------------|   |-----------------------|
-  | TaxService            |  | ShippingService       |  | DiscountService       |
-  | TaxLineFormatter       |  | ShipLineFormatter     |  | DiscountFormatter     |
-  | TaxRateSource          |  | ShipZoneSource        |  | PromoCodeSource       |
-  +--------------------+   +---------------------+   +---------------------+
-         ^
-         |
-     a "tax rule" requirement now touches exactly one component
+AFTER CCP, classes grouped by axis of change
+
++------------------+
+| TaxCalculation   |
+| TaxService       |
+| TaxLineFormatter |
+| TaxRateSource    |
++------------------+
++-------------------+
+| ShippingRules     |
+| ShippingService   |
+| ShipLineFormatter |
+| ShipZoneSource    |
++-------------------+
++-------------------+
+| DiscountEngine    |
+| DiscountService   |
+| DiscountFormatter |
+| PromoCodeSource   |
++-------------------+
+
+A tax rule requirement now touches exactly one component.
 ```
 
 ## 7. Dynamics

--- a/patterns/07-integration/README.md
+++ b/patterns/07-integration/README.md
@@ -2,7 +2,7 @@
 
 Origin. Hohpe and Woolf
 
-54 entries, 385,715 words. Every entry carries all 18
+54 entries, 385,699 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Enterprise Integration
@@ -54,7 +54,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Event-Driven Consumer](event-driven-consumer.md) | canonical | 6,039 | A service needs to react when something happens elsewhere in the system, a payment is captured, an order is placed, a file lands in a bucket, a row is updated in another team's ... |
 | [Format Indicator](format-indicator.md) | canonical | 6,130 | A message travels from a producer to a consumer, and at some point the consumer must decide how to parse the bytes it received. |
 | [Message](message.md) | canonical | 6,901 | Two applications need to exchange information without either one blocking on the other's availability, without either one dictating the other's internal data model, and without a ... |
-| [Message Bus](message-bus.md) | canonical | 7,686 | A system starts with two applications that need to exchange data, and a direct point-to-point integration, a script that reads from one database and writes to another, or a ... |
+| [Message Bus](message-bus.md) | canonical | 7,670 | A system starts with two applications that need to exchange data, and a direct point-to-point integration, a script that reads from one database and writes to another, or a ... |
 | [Message Channel](message-channel.md) | canonical | 6,008 | Two independently deployed pieces of software need to exchange information, and the team building them does not want a synchronous, point-to-point network call between them. |
 | [Message Dispatcher](message-dispatcher.md) | canonical | 7,081 | A single logical stream of work needs to be processed by more capacity than one consumer thread can provide, and the team wants that capacity applied without breaking three ... |
 | [Message Expiration](message-expiration.md) | canonical | 6,898 | A message carries a request or a piece of data across an asynchronous boundary. |

--- a/patterns/07-integration/README.md
+++ b/patterns/07-integration/README.md
@@ -2,7 +2,7 @@
 
 Origin. Hohpe and Woolf
 
-54 entries, 385,782 words. Every entry carries all 18
+54 entries, 385,766 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Enterprise Integration
@@ -54,7 +54,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Event-Driven Consumer](event-driven-consumer.md) | canonical | 6,039 | A service needs to react when something happens elsewhere in the system, a payment is captured, an order is placed, a file lands in a bucket, a row is updated in another team's ... |
 | [Format Indicator](format-indicator.md) | canonical | 6,130 | A message travels from a producer to a consumer, and at some point the consumer must decide how to parse the bytes it received. |
 | [Message](message.md) | canonical | 6,901 | Two applications need to exchange information without either one blocking on the other's availability, without either one dictating the other's internal data model, and without a ... |
-| [Message Bus](message-bus.md) | canonical | 7,686 | A system starts with two applications that need to exchange data, and a direct point-to-point integration, a script that reads from one database and writes to another, or a ... |
+| [Message Bus](message-bus.md) | canonical | 7,670 | A system starts with two applications that need to exchange data, and a direct point-to-point integration, a script that reads from one database and writes to another, or a ... |
 | [Message Channel](message-channel.md) | canonical | 6,008 | Two independently deployed pieces of software need to exchange information, and the team building them does not want a synchronous, point-to-point network call between them. |
 | [Message Dispatcher](message-dispatcher.md) | canonical | 7,081 | A single logical stream of work needs to be processed by more capacity than one consumer thread can provide, and the team wants that capacity applied without breaking three ... |
 | [Message Expiration](message-expiration.md) | canonical | 6,898 | A message carries a request or a piece of data across an asynchronous boundary. |

--- a/patterns/07-integration/message-bus.md
+++ b/patterns/07-integration/message-bus.md
@@ -239,31 +239,34 @@ alternative named instead.
 ## 6. ASCII structure diagram
 
 ```
-                          +-----------------------+
-                          |     Message Bus        |
-                          |  (common data model,   |
-                          |   command set, infra)  |
-                          |                         |
-        publish           |  +-------------------+  |     deliver
-   Order Service --------->  | topic  order.*    |  ---------> Billing Service
-                          |  +-------------------+  |
-                          |                         |     deliver
-                          |  +-------------------+  ---------> Inventory Service
-                          |  | topic  payment.*  |  |
-   Payment Service ------->  +-------------------+  |     deliver
-        publish           |                         ---------> Fraud Check Service
-                          |  +-------------------+  |
-                          |  | topic  shipment.* |  ---------> Shipping Service
-                          |  +-------------------+  |     deliver
-                          +-----------------------+
-                          | Channel Adapter layer  |
-                          | (per-system format     |
-                          |  translation, at edge)  |
-                          +-----------------------+
++-----------------+
+| Order Service   |
+| Payment Service |
++-----------------+
+     | publish
+     v
++----------------------------------------------------+
+| Message Bus, common data model, command set, infra |
+|                                                    |
+| topic order.*                                      |
+| topic payment.*                                    |
+| topic shipment.*                                   |
+|                                                    |
+| Channel Adapter layer (per-system format           |
+| translation, at edge)                              |
++----------------------------------------------------+
+     | deliver
+     v
++---------------------+
+| Billing Service     |
+| Inventory Service   |
+| Fraud Check Service |
+| Shipping Service    |
++---------------------+
 
-  Producers know only. the bus address, the common data model.
-  Consumers know only. the topic(s) they subscribe to.
-  Neither side holds a reference to the other.
+Producers know only the bus address and the common data
+model. Consumers know only the topics they subscribe to.
+Neither side holds a reference to the other.
 ```
 
 ## 7. Dynamics

--- a/patterns/09-concurrency/README.md
+++ b/patterns/09-concurrency/README.md
@@ -2,7 +2,7 @@
 
 Origin. Schmidt POSA 2
 
-40 entries, 318,564 words. Every entry carries all 18
+40 entries, 318,562 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Concurrency
@@ -46,7 +46,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Structured Concurrency](structured-concurrency.md) | established | 7,965 | A function spawns concurrent work, a network call, a background computation, a fan-out to several services, and returns before that work is guaranteed to be done. |
 | [Thread Pool](thread-pool.md) | canonical | 7,592 | A server, or any long-running process, receives a stream of independent units of work. |
 | [Thread-Safe Interface](thread-safe-interface.md) | canonical | 8,248 | An object holds mutable state that more than one thread can reach at the same time, and the object exposes more than one public operation on that state. |
-| [Thread-Specific Storage](thread-specific-storage.md) | canonical | 10,259 | A piece of state is logically global, in the sense that every function in a call chain wants to read or write it through one shared name, and yet the state must physically differ ... |
+| [Thread-Specific Storage](thread-specific-storage.md) | canonical | 10,257 | A piece of state is logically global, in the sense that every function in a call chain wants to read or write it through one shared name, and yet the state must physically differ ... |
 | [Work Queue](work-queue.md) | canonical | 7,614 | A system receives units of work that are independent of each other, and the rate at which work arrives does not match the rate at which any single processor can do it. |
 | [Work Stealing](work-stealing.md) | canonical | 9,657 | A program decomposes into many small units of work, and the units are created dynamically during execution rather than known up front. |
 

--- a/patterns/09-concurrency/thread-specific-storage.md
+++ b/patterns/09-concurrency/thread-specific-storage.md
@@ -300,32 +300,36 @@ Collection each thread resolves the key against is private to that thread.
 ## 6. ASCII structure diagram
 
 ```
-   +----------------------+
-   |  Application Thread  |
-   |----------------------|
-   |  calls getspecific()  |
-   |  calls setspecific()  |
-   +-----------+----------+
-               |
-               v
-   +----------------------+          key           +------------------------+
-   |    TS Object Proxy    | --------------------->  |   TS Object Collection |
-   |------------------------|                        |   (one per thread)      |
-   | + getspecific(): TSObj |                        |-------------------------|
-   | + setspecific(v: TSObj)|                        | + get_object(key): TSObj|
-   | - key                  |                        | + set_object(key, v)    |
-   +------------------------+                        +------------+------------+
-                                                                    |
-                                                                    v
-                                                       +------------------------+
-                                                       |        TS Object        |
-                                                       |  (this thread's copy)   |
-                                                       +------------------------+
++---------------------+
+| Application Thread  |
+| calls getspecific() |
+| calls setspecific() |
++---------------------+
+           |
+           v
++-------------------------+
+| TS Object Proxy         |
+| + getspecific(): TSObj  |
+| + setspecific(v: TSObj) |
+| - key                   |
++-------------------------+
+           | resolves key against
+           v
++---------------------------------------+
+| TS Object Collection (one per thread) |
+| + get_object(key): TSObj              |
+| + set_object(key, v)                  |
++---------------------------------------+
+           |
+           v
++--------------------------------+
+| TS Object (this thread's copy) |
++--------------------------------+
 
-   One Proxy instance is shared by every Application Thread.
-   Each thread's Collection is private to that thread.
-   The same key, resolved against a different Collection,
-   reaches a different TS Object.
+One Proxy instance is shared by every Application
+Thread. Each thread's Collection is private to that
+thread. The same key, resolved against a different
+Collection, reaches a different TS Object.
 ```
 
 ## 7. Dynamics

--- a/patterns/11-domain-driven-design/README.md
+++ b/patterns/11-domain-driven-design/README.md
@@ -2,7 +2,7 @@
 
 Origin. Evans, Vernon
 
-35 entries, 264,744 words. Every entry carries all 18
+35 entries, 264,620 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Anti-pattern
@@ -33,7 +33,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Application Service](application-service.md) | canonical | 7,949 | A rich domain model, built from entities, value objects, and aggregates that enforce their own invariants, still needs a caller. |
 | [Domain Service](domain-service.md) | canonical | 7,032 | A team modeling a domain in an object-oriented style eventually meets an operation that genuinely spans more than one object and does not belong to either. |
 | [Factory](factory.md) | canonical | 8,338 | A domain model accumulates two kinds of complexity as it grows. |
-| [Module](module.md) | canonical | 7,323 | A domain model that stays in one undifferentiated pile of classes becomes unreadable long before it becomes incorrect. |
+| [Module](module.md) | canonical | 7,280 | A domain model that stays in one undifferentiated pile of classes becomes unreadable long before it becomes incorrect. |
 | [Repository](repository.md) | canonical | 6,776 | A domain layer needs to load and save the objects it works with, but the code that expresses business rules should not know whether an order lives in PostgreSQL, in a document ... |
 | [Specification](specification.md) | canonical | 7,066 | A domain accumulates rules that decide whether an object qualifies for something. |
 | [Value Object](value-object.md) | canonical | 7,547 | A domain model accumulates concepts that are not things, they are measurements, descriptions, or quantities. |
@@ -68,7 +68,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Context Map](context-map.md) | canonical | 7,294 | A system reaches a certain size and a certain number of contributing teams before a single, internally consistent domain model stops being achievable. |
 | [Core Domain](core-domain.md) | canonical | 6,670 | A team building a non-trivial system faces a resource allocation problem long before it faces a technical one. |
 | [Customer-Supplier](customer-supplier.md) | canonical | 7,914 | Any system large enough to be split across more than one Bounded Context, see the bounded-context entry in this repository, produces integration points where one context's model ... |
-| [Open Host Service](open-host-service.md) | canonical | 9,358 | A bounded context that has real internal complexity attracts multiple downstream consumers over time. |
+| [Open Host Service](open-host-service.md) | canonical | 9,277 | A bounded context that has real internal complexity attracts multiple downstream consumers over time. |
 | [Partnership](partnership.md) | canonical | 7,024 | Two teams each own a Bounded Context, and the two Contexts must integrate, but neither team can honestly claim to be upstream of the other. |
 | [Separate Ways](separate-ways.md) | canonical | 9,250 | A team splits a system into more than one Bounded Context for good reasons, because two departments' vocabularies genuinely diverge, because two teams cannot coordinate closely ... |
 | [Shared Kernel](shared-kernel.md) | canonical | 7,403 | Two Bounded Contexts model a piece of the domain in a compatible way, not because either team designed it that way on purpose, but because the concept genuinely is the same ... |

--- a/patterns/11-domain-driven-design/module.md
+++ b/patterns/11-domain-driven-design/module.md
@@ -197,33 +197,37 @@ kind tends to grow and is the one most often split later.
 ## 6. ASCII structure diagram
 
 ```
-+-------------------------------------------------------------+
-|                     Bounded Context. Ordering                |
-|                                                                |
-|  +----------------------+       +--------------------------+ |
-|  |  Module. order        |       |  Module. shipping         | |
-|  |------------------------|       |----------------------------| |
-|  |  Order (Aggregate)     |------>|  ShippingLabel (Aggregate)| |
-|  |  OrderLine (Entity)    | reads |  Carrier (Value Object)   | |
-|  |  Money (Value Object)  |       |  ShippingRepository       | |
-|  |  OrderRepository       |       |  (interface)               | |
-|  |  (interface)           |       +--------------------------+ |
-|  +-----------+------------+                                    |
-|              |                                                 |
-|              | publishes                                       |
-|              v                                                 |
-|  +----------------------------------+                          |
-|  |  Module. shared_kernel            |                          |
-|  |------------------------------------| <-- referenced by both  |
-|  |  CustomerId (Value Object)         |     order and shipping  |
-|  |  Money (Value Object, shared type) |                          |
-|  |  DomainEvent (marker interface)    |                          |
-|  +----------------------------------+                          |
-+-------------------------------------------------------------+
+Bounded Context, Ordering
 
-Legend
-  ------->   a public dependency, arrow points from consumer to depended-on module
-  A box's inner list is that module's exported model elements only
++-----------------------------+
+| Module: order               |
+| Order (Aggregate)           |
+| OrderLine (Entity)          |
+| Money (Value Object)        |
+| OrderRepository (interface) |
++-----------------------------+
+           | reads
+           v
++--------------------------------+
+| Module: shipping               |
+| ShippingLabel (Aggregate)      |
+| Carrier (Value Object)         |
+| ShippingRepository (interface) |
++--------------------------------+
+           |
+           | both publish to
+           v
++---------------------------------------+
+| Module: shared_kernel                 |
+| referenced by both order and shipping |
+| CustomerId (Value Object)             |
+| Money (Value Object, shared type)     |
+| DomainEvent (marker interface)        |
++---------------------------------------+
+
+Legend. an arrow is a public dependency, pointing from
+consumer to depended-on module. A box's inner list is
+that module's exported model elements only.
 ```
 
 The diagram deliberately shows one shared, small module (`shared_kernel`)

--- a/patterns/11-domain-driven-design/open-host-service.md
+++ b/patterns/11-domain-driven-design/open-host-service.md
@@ -265,41 +265,44 @@ frontend.
 ## 6. ASCII structure diagram
 
 ```
-   Upstream Bounded Context
-   +-----------------------------------------------------------+
-   |                                                            |
-   |   +------------------+          +----------------------+  |
-   |   |  Internal Domain |  reads   |   Host Translator    |  |
-   |   |  Model           |  ------->|   (Open Host Service  |  |
-   |   |  (aggregates,    |          |    adapter layer)     |  |
-   |   |  invariants)     |          +-----------+----------+  |
-   |   +------------------+                      |             |
-   |          ^  changes freely,                 | emits       |
-   |          |  no external notice needed        v             |
-   |          |                       +----------------------+  |
-   |          +---------------------- | Published Language   |  |
-   |                                  | (versioned schema.   |  |
-   |                                  |  OpenAPI, Protobuf,  |  |
-   |                                  |  event contract)     |  |
-   |                                  +-----------+----------+  |
-   +----------------------------------------------|-------------+
-                                                    |
-                        one stable, documented, versioned protocol
-                                                    |
-            +---------------------+----------------+---------------------+
-            |                     |                                      |
-            v                     v                                      v
-   +-----------------+   +-----------------+                   +-----------------+
-   |  Consumer A     |   |  Consumer B     |        ...        |  Consumer N     |
-   |  (own model,    |   |  (own model,    |                   |  (own model,    |
-   |  translates     |   |  translates     |                   |  translates     |
-   |  Published Lang |   |  Published Lang |                   |  Published Lang |
-   |  into its own)  |   |  into its own)  |                   |  into its own)  |
-   +-----------------+   +-----------------+                   +-----------------+
+Upstream Bounded Context
 
-   Only the Host Translator sees both the internal model and the
-   Published Language. No consumer, and no part of the internal model,
-   ever crosses that boundary directly.
++------------------------+
+| Internal Domain Model  |
+| aggregates, invariants |
++------------------------+
+     | reads
+     v
++---------------------------------------------------+
+| Host Translator (Open Host Service adapter layer) |
++---------------------------------------------------+
+     | emits
+     v
++--------------------------------------------+
+| Published Language                         |
+| versioned schema, OpenAPI, Protobuf, event |
+| contract                                   |
++--------------------------------------------+
+
+Internal Domain Model changes freely, no external notice
+needed. Only the Host Translator sees both the internal
+model and the Published Language.
+
+One stable, documented, versioned protocol, downstream:
+
++--------------------------------------------------+
+| Consumer A, own model, translates Published Lang |
++--------------------------------------------------+
++--------------------------------------------------+
+| Consumer B, own model, translates Published Lang |
++--------------------------------------------------+
+...
++--------------------------------------------------+
+| Consumer N, own model, translates Published Lang |
++--------------------------------------------------+
+
+No consumer, and no part of the internal model, ever
+crosses the Host Translator boundary directly.
 ```
 
 ## 7. Dynamics

--- a/patterns/12-data-storage/README.md
+++ b/patterns/12-data-storage/README.md
@@ -2,7 +2,7 @@
 
 Origin. Kleppmann
 
-45 entries, 319,818 words. Every entry carries all 18
+45 entries, 319,823 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Concurrency Control
@@ -50,7 +50,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Leaderless Replication](leaderless-replication.md) | canonical | 7,925 | A single-leader replicated database routes every write through one node. |
 | [Log Compaction](log-compaction.md) | established | 8,019 | An append-only log is the simplest and most dependable storage primitive a distributed system offers. |
 | [Medallion Architecture](medallion-architecture.md) | established | 7,094 | A data platform ingests information from many upstream systems. |
-| [Multi-Leader Replication](multi-leader-replication.md) | established | 7,906 | A team runs a database that serves write traffic from more than one geographic region, or from more than one autonomous system that must keep working during a network partition ... |
+| [Multi-Leader Replication](multi-leader-replication.md) | established | 7,911 | A team runs a database that serves write traffic from more than one geographic region, or from more than one autonomous system that must keep working during a network partition ... |
 | [Multiversion Concurrency Control](mvcc.md) | canonical | 7,230 | A database serves many concurrent transactions. |
 | [Quorum](quorum.md) | canonical | 7,448 | A system replicates the same piece of data onto several nodes so that the loss of any one node, or the temporary unavailability of any one node, does not lose data or stop the ... |
 | [Read Repair](read-repair.md) | canonical | 6,416 | A system with leaderless, quorum-based replication accepts writes on any of several replicas for a key, and a temporarily unreachable replica, a dropped message, or a slow node ... |

--- a/patterns/12-data-storage/multi-leader-replication.md
+++ b/patterns/12-data-storage/multi-leader-replication.md
@@ -256,28 +256,35 @@ The participants in a multi-leader replication topology are as follows.
 ## 6. ASCII structure diagram
 
 ```
-                        MULTI-LEADER REPLICATION
-                        (all-to-all mesh, 3 regions)
+MULTI-LEADER REPLICATION
+all-to-all mesh, 3 regions
 
-        +-------------------+       replication link       +-------------------+
-        |  Leader A (EU)    | <---------------------------> |  Leader B (US)    |
-        |  local WAL / log  |                                |  local WAL / log  |
-        |  version metadata |                                |  version metadata |
-        +---------+---------+                                +---------+---------+
-                  ^                                                     ^
-                  |            replication link                        |
-                  |     +---------------------------------------+      |
-                  +---> |          Leader C (APAC)              | <----+
-                        |  local WAL / log                       |
-                        |  version metadata                      |
-                        +-----------------------------------------+
++------------------+
+| Leader A (EU)    |
+| local WAL / log  |
+| version metadata |
++------------------+
+        <-- replication link -->
++------------------+
+| Leader B (US)    |
+| local WAL / log  |
+| version metadata |
++------------------+
+        <-- replication link -->
++------------------+
+| Leader C (APAC)  |
+| local WAL / log  |
+| version metadata |
++------------------+
+        <-- replication link, A and C connect directly too -->
 
-        Each leader accepts local reads and writes.
-        Each replication link is async, may lag, may partition independently.
-        A write applied at A is queued to replicate to both B and C.
-        A write applied concurrently at B for the same record is a
-        conflict once it arrives at A or C. neither write happened
-        before the other in the version metadata's partial order.
+Each leader accepts local reads and writes. Each
+replication link is async, may lag, may partition
+independently. A write applied at A is queued to
+replicate to both B and C. A write applied concurrently
+at B for the same record is a conflict once it arrives
+at A or C, neither write happened before the other in
+the version metadata's partial order.
 ```
 
 ## 7. Dynamics

--- a/patterns/13-frontend-ui/README.md
+++ b/patterns/13-frontend-ui/README.md
@@ -2,7 +2,7 @@
 
 Origin. Framework documentation
 
-34 entries, 123,837 words. Every entry carries all 18
+34 entries, 123,829 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Application Architecture
@@ -21,7 +21,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
-| [Atomic Design](atomic-design.md) | established | 3,690 | Before Atomic Design, a component library commonly organized components by feature or by page, a folder for the checkout flow next to a folder for the settings page, which left no ... |
+| [Atomic Design](atomic-design.md) | established | 3,682 | Before Atomic Design, a component library commonly organized components by feature or by page, a folder for the checkout flow next to a folder for the settings page, which left no ... |
 
 ## Component Composition
 

--- a/patterns/13-frontend-ui/atomic-design.md
+++ b/patterns/13-frontend-ui/atomic-design.md
@@ -129,19 +129,27 @@ directly below it.
 ## 6. ASCII structure diagram
 
 ```
-  Pages          [ Real content assembled into a template's layout ]
-                              ^
-                              |
-  Templates      [ Organisms arranged to show layout, placeholder content ]
-                              ^
-                              |
-  Organisms      [ Header = Logo(atom) + NavMenu(molecule) + SearchBar(molecule) ]
-                              ^
-                              |
-  Molecules      [ SearchBar = Label(atom) + Input(atom) + Button(atom) ]
-                              ^
-                              |
-  Atoms          [ Label ]  [ Input ]  [ Button ]
+Pages
+  Real content assembled into a template's layout
+    ^
+    |
+Templates
+  Organisms arranged to show layout, placeholder
+  content
+    ^
+    |
+Organisms
+  Header = Logo (atom) + NavMenu (molecule) +
+  SearchBar (molecule)
+    ^
+    |
+Molecules
+  SearchBar = Label (atom) + Input (atom) +
+  Button (atom)
+    ^
+    |
+Atoms
+  Label, Input, Button
 ```
 
 ## 7. Dynamics

--- a/patterns/14-testing/README.md
+++ b/patterns/14-testing/README.md
@@ -2,7 +2,7 @@
 
 Origin. Meszaros, xUnit Test Patterns
 
-30 entries, 217,017 words. Every entry carries all 18
+30 entries, 217,034 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Test Data
@@ -16,9 +16,9 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
-| [Dummy](dummy.md) | canonical | 6,531 | A constructor, a factory function, or a method signature requires an argument of a particular type, but the code path being exercised by a specific test does not use that argument ... |
+| [Dummy](dummy.md) | canonical | 6,529 | A constructor, a factory function, or a method signature requires an argument of a particular type, but the code path being exercised by a specific test does not use that argument ... |
 | [Fake](fake.md) | canonical | 6,405 | A piece of code depends on a collaborator that is real, correct, and slow, or real, correct, and hard to set up. |
-| [Mock](mock.md) | canonical | 6,117 | A unit of code under test calls a method on a collaborator, and the whole reason the test exists is to prove that call happens, with the right arguments, in the right ... |
+| [Mock](mock.md) | canonical | 6,136 | A unit of code under test calls a method on a collaborator, and the whole reason the test exists is to prove that call happens, with the right arguments, in the right ... |
 | [Stub](stub.md) | canonical | 9,016 | Code under test frequently depends on something the test cannot, or should not, use as it really behaves. |
 
 ## Test Structure

--- a/patterns/14-testing/dummy.md
+++ b/patterns/14-testing/dummy.md
@@ -198,22 +198,32 @@ contract, never behavioral.
 ## 6. ASCII structure diagram
 
 ```
-+-------------------+           depends on           +----------------------+
-|  Test method       |------------------------------->|  Dependency interface |
-|                     |  constructs SUT with           |  (PaymentGateway,     |
-|                     |    - realArg  (matters)        |   Logger, etc.)       |
-|                     |    - dummyArg (does not matter) +----------------------+
-+---------+-----------+                                          ^
-          |                                                       |
-          | passes both args                                     | implements
-          v                                                       |
-+---------------------------+                          +----------------------+
-|  System under test         |----- calls realArg ---->|  Real / Stub / Fake   |
-|  (OrderProcessor)          |                          |  (behavior matters)  |
-|                             |----- calls dummyArg ---X|  Dummy                |
-+---------------------------+   never actually invoked  |  (no behavior,       |
-                                 by this test path       |   or throws if used) |
-                                                          +----------------------+
++------------------------------+
+| Test method                  |
+| constructs SUT with          |
+|   realArg  (matters)         |
+|   dummyArg (does not matter) |
++------------------------------+
+     | passes both args
+     v
++------------------------------------+
+| System under test (OrderProcessor) |
++------------------------------------+
+     | calls realArg
+     v
++--------------------------------------+
+| Real / Stub / Fake, behavior matters |
++--------------------------------------+
+
+The same SUT also calls dummyArg on its constructor
+interface, but this test path never actually invokes it:
+
++---------------------------------------+
+| Dummy, no behavior, or throws if used |
++---------------------------------------+
+
+Both Real / Stub / Fake and Dummy implement the same
+Dependency interface, e.g. PaymentGateway or Logger.
 ```
 
 ## 7. Dynamics

--- a/patterns/14-testing/mock.md
+++ b/patterns/14-testing/mock.md
@@ -186,21 +186,36 @@ originally described.
 ## 6. ASCII structure diagram
 
 ```
-+------------------+           depends on            +---------------------+
-|  Test Code       |------------------------------->  | Collaborator        |
-|                  |         (constructs, injects)    | Interface           |
-|  1. build mock   |                                  | (the seam)          |
-|  2. set          |                                  +----------^----------+
-|     expectations |                                             |
-|  3. inject mock  |                                    implements|implements
-|  4. exercise SUT |                                             |
-|  5. verify mock  |         +--------------------------+   +----+----------+
-+---------+--------+         |  System Under Test        |   | Mock Object   |
-          |    2, 5           |                          |   |               |
-          +-------------------> uses Collaborator via ---+-->| expected calls|
-                               | injected reference        |   | actual calls  |
-                               +----------------------------+  | verify()      |
-                                                                 +---------------+
++---------------------+
+| Test Code           |
+| 1. build mock       |
+| 2. set expectations |
+| 3. inject mock      |
+| 4. exercise SUT     |
+| 5. verify mock      |
++---------------------+
+     | depends on (constructs, injects)
+     v
++-----------------------------------+
+| Collaborator Interface (the seam) |
++-----------------------------------+
+     ^ implemented by two classes
+
++-----------------------+
+| System Under Test     |
+| uses Collaborator via |
+| injected reference    |
++-----------------------+
++----------------+
+| Mock Object    |
+| expected calls |
+| actual calls   |
+| verify()       |
++----------------+
+
+Test Code exercises the SUT (step 4) and later verifies
+the Mock (step 5). The SUT reaches the Mock only through
+the Collaborator Interface, never a concrete reference.
 ```
 
 ## 7. Dynamics


### PR DESCRIPTION
## Summary

- Redraws ten more ASCII diagrams that exceeded 78 characters wide,
  the next tier at 82 characters, down to 40 to 62 characters.
- encapsulate-record.md, common-closure-principle.md, message-bus.md,
  thread-specific-storage.md, module.md, open-host-service.md,
  multi-leader-replication.md, atomic-design.md, dummy.md, mock.md.
- No structural, prose, reference, or code content changed. Only the
  diagram fences.
- tools/gen-indexes.py was re-run before this commit, regenerating the
  seven family index tables these entries span.

## Notable redesigns

- common-closure-principle.md had two three-column groupings, before
  CCP (Entities, Services, Formatters) and after CCP (TaxCalculation,
  ShippingRules, DiscountEngine). Both became stacked boxes instead of
  side by side columns.
- multi-leader-replication.md is a genuine all-to-all mesh across
  three regions. It stays a mesh, narrowed, with the direct A to C
  replication link named explicitly in prose rather than drawn as a
  diagonal arrow, since a true diagonal cannot be drawn narrow.
- open-host-service.md's downstream consumer row (Consumer A, B,
  through N) is now a stacked list with an ellipsis between the named
  consumer and the N-th one, the same shape as the original's
  horizontal ellipsis.

## Test plan

- [x] check-structure.py, 884 of 884 entries pass
- [x] check-prose.py, 925 of 925 entries pass
- [x] markdownlint-cli2 0.23.2, 0 issues on the ten changed files
- [x] validate-refs.py --strict, every citation resolves
- [x] check-code.py --strict, 2826 compiled, 0 failed, 0 skipped
- [x] gen-indexes.py re-run, seven family README tables regenerated and
      committed alongside the content changes
- [x] git diff --stat -- docs and dist and the root README.md, all
      empty, no unexpected top level changes

47 more entries with the same width issue remain, to be worked through
in following batches.
