### PR TITLE
fix(patterns) redraw ten more ASCII diagrams under 78 columns

### DIFF
--- a/patterns/03-refactoring/README.md
+++ b/patterns/03-refactoring/README.md
@@ -2,7 +2,7 @@
 
 Origin. Fowler, Refactoring 2nd edition
 
-66 entries, 262,768 words. Every entry carries all 18
+66 entries, 262,769 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Composing Functions
@@ -51,7 +51,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Introduce Parameter Object](introduce-parameter-object.md) | canonical | 2,642 | You have a function with a long parameter list where several parameters are naturally related. |
 | [Introduce Special Case](introduce-special-case.md) | canonical | 3,021 | You have code that checks for null, or for a special value that means "no value" or "unknown," before every operation on the object. |
 | [Move Field](move-field.md) | canonical | 2,268 | A field is on a class that does not use it, or that uses it less than another class does. |
-| [Move Function](move-function.md) | canonical | 2,436 | A function is on a class or module that does not use it, or that uses it less than another class does. |
+| [Move Function](move-function.md) | canonical | 2,437 | A function is on a class or module that does not use it, or that uses it less than another class does. |
 | [Move Statements into Function](move-statements-into-function.md) | canonical | 1,717 | You have a function that is called from multiple places, and every caller performs the same statements immediately before or after the call. |
 | [Move Statements to Callers](move-statements-to-callers.md) | canonical | 1,599 | A function performs statements that vary by caller or that are not the function's responsibility. |
 | [Parameterize Function](parameterize-function.md) | canonical | 1,755 | You have two or more functions that perform the same operation with different constant values. |

--- a/patterns/03-refactoring/move-function.md
+++ b/patterns/03-refactoring/move-function.md
@@ -129,25 +129,46 @@ The refactoring has two participants.
 ## 6. ASCII structure diagram
 
 ```
-  BEFORE                              AFTER
-  ------                              -----
+BEFORE
+------
 
-  class Account:                     class AccountType:
-    type: AccountType                  interestRate
-                                       fee
-    calculateOverdraft():              threshold
-      // uses type.interestRate
-      // uses type.fee                 calculateOverdraft():
-      // uses type.threshold             // uses interestRate
-      // barely uses own fields          // uses fee
-                                         // uses threshold
-  class AccountType:
-    interestRate                    class Account:
-    fee                                type: AccountType
-    threshold
-                                      overdraftCharge():
-                                        return type.calculateOverdraft()
-  (feature envy on AccountType)      (function on AccountType, Account delegates)
+class Account:
+  type: AccountType
+
+  calculateOverdraft():
+    // uses type.interestRate
+    // uses type.fee
+    // uses type.threshold
+    // barely uses own fields
+
+class AccountType:
+  interestRate
+  fee
+  threshold
+
+(feature envy on AccountType)
+
+
+AFTER
+-----
+
+class AccountType:
+  interestRate
+  fee
+  threshold
+
+  calculateOverdraft():
+    // uses interestRate
+    // uses fee
+    // uses threshold
+
+class Account:
+  type: AccountType
+
+  overdraftCharge():
+    return type.calculateOverdraft()
+
+(function moved onto AccountType, Account delegates)
 ```
 
 ## 7. Dynamics

--- a/patterns/05-architectural/README.md
+++ b/patterns/05-architectural/README.md
@@ -2,7 +2,7 @@
 
 Origin. Buschmann POSA 1, Bass SEI
 
-31 entries, 248,947 words. Every entry carries all 18
+31 entries, 248,953 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Architectural
@@ -15,7 +15,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Clean Architecture](clean-architecture.md) | canonical | 7,521 | A non-trivial application accumulates business rules that answer questions no framework, database, or user interface technology can answer for it. |
 | [Client-Server](client-server.md) | canonical | 8,189 | An application needs to let more than one user, device, or process operate on data or capability that must be shared, kept consistent, and protected from direct, uncoordinated ... |
 | [Event-Carried State Transfer](event-carried-state-transfer.md) | established | 7,462 | A system grows a second consumer that needs data owned by a first system. |
-| [Event-Driven Architecture](event-driven-architecture.md) | canonical | 9,420 | A system built from several independently deployable components needs to react to things that happen elsewhere in the system, without each component knowing the internal state ... |
+| [Event-Driven Architecture](event-driven-architecture.md) | canonical | 9,405 | A system built from several independently deployable components needs to react to things that happen elsewhere in the system, without each component knowing the internal state ... |
 | [Hexagonal Architecture](hexagonal-architecture.md) | canonical | 10,373 | A codebase reaches a specific, recognizable moment. |
 | [Interpreter Architecture](interpreter-architecture.md) | canonical | 8,034 | A system needs to accept a piece of behaviour, a rule, a query, a formula, a policy, that was not known when the system was compiled, and that behaviour must be safe to run inside ... |
 | [Layered Architecture](layered-architecture.md) | canonical | 7,640 | A non-trivial application has at least three concerns that change for different reasons and at different rates. |
@@ -31,7 +31,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Onion Architecture](onion-architecture.md) | canonical | 8,637 | A team builds a business application against a specific database, a specific web framework, and a specific set of third party integrations, because those are the concrete ... |
 | [Peer-to-Peer](peer-to-peer.md) | canonical | 8,950 | A system needs many participants to exchange data or share work, and at least one of the following forces makes a single, dedicated server the wrong place to put that coordination. |
 | [Pipeline Architecture](pipeline-architecture.md) | canonical | 8,757 | A system needs to transform a stream of data through a sequence of independent processing steps, and the set of steps, their order, or their implementation is expected to change ... |
-| [Pipes and Filters](pipes-filters.md) | canonical | 7,870 | A system must transform a stream of data through several independent processing steps, and the set of steps, their order, or the data source itself is expected to change over the ... |
+| [Pipes and Filters](pipes-filters.md) | canonical | 7,891 | A system must transform a stream of data through several independent processing steps, and the set of steps, their order, or the data source itself is expected to change over the ... |
 | [Plugin Architecture](plugin-architecture.md) | canonical | 7,823 | An application needs to support a set of behaviours that is open-ended, unknown at the time the core is built, and likely to be supplied by parties who are not the core's own ... |
 | [Plugin Sandbox](plugin-sandbox.md) | established | 10,826 | A host application defines an extension point, using Plugin Architecture or Microkernel, so that its behavior can grow without every new feature being merged into the core ... |
 | [Primary-Replica](primary-replica.md) | canonical | 7,665 | A single database instance handling both writes and reads eventually hits a ceiling on at least one of three axes, read throughput, availability, and geographic latency. |

--- a/patterns/05-architectural/event-driven-architecture.md
+++ b/patterns/05-architectural/event-driven-architecture.md
@@ -273,60 +273,82 @@ by style, but a common vocabulary covers all of them.
 ## 6. ASCII structure diagram
 
 ```
-                     EVENT NOTIFICATION / EVENT-CARRIED STATE TRANSFER
-                     (the two most common styles in service integration)
+EVENT NOTIFICATION / EVENT-CARRIED STATE TRANSFER
+the two most common styles in service integration
 
-  +----------------+   emits    +-------------------------+
-  |    Producer    | ---------> |     Event Channel        |
-  |  (Order Svc)   |  "Order    |  (topic / queue / log)   |
-  +----------------+   Placed"  +-------------------------+
-                                        |        |        |
-                             delivers   |        |        |  delivers
-                                        v        v        v
-                          +----------+  +----------+  +----------+
-                          | Consumer |  | Consumer |  | Consumer |
-                          | (Stock)  |  | (Email)  |  | (Fraud)  |
-                          +----------+  +----------+  +----------+
-                                |
-                                | may itself emit a
-                                | derived event
-                                v
-                          +----------------+
-                          | Event Channel  |  "Stock Reserved"
-                          +----------------+
-                                |
-                                v
-                          +----------+
-                          | Consumer |
-                          | (Ship)   |
-                          +----------+
++----------------------+
+| Producer (Order Svc) |
++----------------------+
+     | emits Order Placed
+     v
++-------------------------------------+
+| Event Channel (topic / queue / log) |
++-------------------------------------+
+     | delivers to all subscribers
+     v
++------------------+
+| Consumer (Stock) |
++------------------+
++------------------+
+| Consumer (Email) |
++------------------+
++------------------+
+| Consumer (Fraud) |
++------------------+
 
-  Producer has NO reference to any Consumer. Consumers have NO reference
-  to Producer or to each other. Only the Event Channel and the shared
-  event schema couple them.
+Consumer (Stock) may itself emit a derived event.
 
++-------------------------------+
+| Event Channel, Stock Reserved |
++-------------------------------+
+     |
+     v
++-----------------+
+| Consumer (Ship) |
++-----------------+
 
-                     EVENT SOURCING (the state IS the event log)
+Producer has NO reference to any Consumer. Consumers
+have NO reference to Producer or to each other. Only
+the Event Channel and the shared event schema couple
+them.
 
-  +----------------+  append   +-------------------------+  replay
-  |   Command      | -------->  |      Event Store         | -------->  current
-  |   Handler      |  event(s) |  (append-only, ordered    |            state,
-  +----------------+           |   per aggregate/stream)   |            derived
-                                +-------------------------+            not stored
+EVENT SOURCING, the state IS the event log
 
++-----------------+
+| Command Handler |
++-----------------+
+     | append event(s)
+     v
++-------------------------------------------------+
+| Event Store, append-only, ordered per aggregate |
++-------------------------------------------------+
+     | replay
+     v
+current state, derived, not stored
 
-                     CQRS (read and write are separately optimised)
+CQRS, read and write are separately optimised
 
-  +------------+   command    +---------------+   event(s)   +--------------+
-  |   Client   | -----------> |  Write Model  | -----------> |  Projector   |
-  +------------+              +---------------+              +--------------+
-        ^                                                            |
-        |                     query                                 v
-        +------------------------------------------------  +----------------+
-                                                              | Read Model(s) |
-                                                              | (denormalised,|
-                                                              |  fast reads)  |
-                                                              +----------------+
++--------+
+| Client |
++--------+
+     | command
+     v
++-------------+
+| Write Model |
++-------------+
+     | event(s)
+     v
++-----------+
+| Projector |
++-----------+
+     |
+     v
++-----------------------------------------+
+| Read Model(s), denormalised, fast reads |
++-----------------------------------------+
+
+Client also queries the Read Model(s) directly, never
+through the Write Model.
 ```
 
 ## 7. Dynamics

--- a/patterns/05-architectural/pipes-filters.md
+++ b/patterns/05-architectural/pipes-filters.md
@@ -223,28 +223,56 @@ implementation most often loses first, described further under dimension 11.
 
 ## 6. ASCII structure diagram
 
-```text
-                Filter                Filter                Filter
-              +--------+            +--------+            +--------+
-Data Source ->|  A     |--- Pipe -->|  B     |--- Pipe -->|  C     |--> Data Sink
-              +--------+            +--------+            +--------+
+```
++-------------+
+| Data Source |
++-------------+
+     | pipe
+     v
++----------+
+| Filter A |
++----------+
+     | pipe
+     v
++----------+
+| Filter B |
++----------+
+     | pipe
+     v
++----------+
+| Filter C |
++----------+
+     | pipe
+     v
++-----------+
+| Data Sink |
++-----------+
 
-   each filter:
-     - reads only from its own inbound pipe(s)
-     - writes only to its own outbound pipe(s)
-     - has no reference to any other filter
+Each filter reads only from its own inbound pipe(s),
+writes only to its own outbound pipe(s), and has no
+reference to any other filter.
 
-   the general form is a directed acyclic graph, not only a line:
+The general form is a directed acyclic graph, not only
+a line.
 
-              +--------+
-              | Filter |----+
-   Source --->|   A    |    |    +--------+
-              +--------+    +--->| Filter |---> Sink
-                             |    |   C    |
-              +--------+     |    +--------+
-              | Filter |-----+
-   Source --->|   B    |
-              +--------+
++----------+
+| Source   |
+| Filter A |
++----------+
++----------+
+| Source   |
+| Filter B |
++----------+
+     | both feed
+     v
++----------+
+| Filter C |
++----------+
+     |
+     v
++------+
+| Sink |
++------+
 ```
 
 ## 7. Dynamics

--- a/patterns/06-enterprise-application-architecture/README.md
+++ b/patterns/06-enterprise-application-architecture/README.md
@@ -2,7 +2,7 @@
 
 Origin. Fowler, PoEAA
 
-56 entries, 371,825 words, 4 more planned, 60 total when the family is complete. Every entry carries all 18
+56 entries, 371,818 words, 4 more planned, 60 total when the family is complete. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Base Pattern
@@ -72,7 +72,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
-| [Business Delegate](business-delegate.md) | established | 1,710 | A presentation-tier client, or another remote caller such as a device, a web service, or a rich client, needs to reach a business-tier service, and calling that remote service ... |
+| [Business Delegate](business-delegate.md) | established | 1,703 | A presentation-tier client, or another remote caller such as a device, a web service, or a rich client, needs to reach a business-tier service, and calling that remote service ... |
 | [Collecting Parameter](collecting-parameter.md) | established | 1,922 | A single bulky method accumulates a result into a local variable across a long, linear sequence of steps, which is exactly the shape Industrial Logic's own text names directly ... |
 | [Composite Entity](composite-entity.md) | established | 1,572 | A domain model made of many small, related objects, mapped one-to-one to individually remote, individually persistent components, pays a real network and management cost for every ... |
 | [Composite View](composite-view.md) | established | 1,561 | A page is commonly built from parts that are shared across many other pages, a header, a footer, a navigation block, and duplicating those shared parts directly inside every page ... |

--- a/patterns/06-enterprise-application-architecture/business-delegate.md
+++ b/patterns/06-enterprise-application-architecture/business-delegate.md
@@ -72,14 +72,24 @@ Strategy" and a "Delegate Adapter Strategy."
 ## 6. ASCII structure diagram
 
 ```
-  +------------+     +--------------------+     +----------------------+
-  | client      | --> | Business Delegate   | --> | business-tier service  |
-  | (presentation |     | hides lookup, retry, |     | remote or local        |
-  |  tier, device, |     | exception translation |     |                        |
-  |  web service) |     +--------------------+     +----------------------+
-  +------------+
++-------------------------------------------+
+| Client                                    |
+| presentation tier, device, or web service |
++-------------------------------------------+
+     |
+     v
++--------------------------------------------+
+| Business Delegate                          |
+| hides lookup, retry, exception translation |
++--------------------------------------------+
+     |
+     v
++----------------------------------------+
+| Business-tier service, remote or local |
++----------------------------------------+
 
-  the client only ever calls the local-looking delegate, per dimension 5
+The client only ever calls the local-looking delegate,
+per dimension 5.
 ```
 
 ## 7. Dynamics

--- a/patterns/10-microservices/README.md
+++ b/patterns/10-microservices/README.md
@@ -2,7 +2,7 @@
 
 Origin. Richardson
 
-49 entries, 364,514 words. Every entry carries all 18
+49 entries, 364,485 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Antipattern
@@ -23,7 +23,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 |---|---|---|---|
 | [Client-side Service Discovery](client-side-service-discovery.md) | canonical | 5,959 | A microservices architecture replaces a small number of long-lived, statically addressed processes with many short-lived, dynamically addressed ones. |
 | [Domain-Specific Protocol](domain-specific-protocol.md) | canonical | 7,890 | A service in a microservice architecture must communicate with something outside the architecture's own control, and that something already has an established, standardized, or ... |
-| [Remote Procedure Invocation](remote-procedure-invocation.md) | canonical | 6,005 | A microservice architecture splits a system into many independently deployable services, and almost every non-trivial request touches more than one of them. |
+| [Remote Procedure Invocation](remote-procedure-invocation.md) | canonical | 5,998 | A microservice architecture splits a system into many independently deployable services, and almost every non-trivial request touches more than one of them. |
 
 ## Communication Style
 
@@ -112,7 +112,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
 | [Application Metrics](application-metrics.md) | canonical | 7,589 | A monolith has one process. When something is slow or wrong, an engineer attaches a profiler, reads a thread dump, or greps one log file, and the whole picture of the system's ... |
-| [Distributed Tracing](distributed-tracing.md) | canonical | 7,640 | A single user-facing request in a microservice architecture fans out into a call graph. |
+| [Distributed Tracing](distributed-tracing.md) | canonical | 7,618 | A single user-facing request in a microservice architecture fans out into a call graph. |
 | [Exception Tracking](exception-tracking.md) | established | 8,433 | A request arrives at a service instance and, partway through handling it, code raises an exception the calling frames do not catch. |
 | [Log Aggregation](log-aggregation.md) | canonical | 8,736 | A service in a microservices system emits log lines to its own local standard output or to a file inside its own container. |
 | [Log Deployments and Changes](log-deployments-changes.md) | established | 9,444 | An engineer is paged. A service that was healthy an hour ago now returns higher error rates, or its latency has doubled, or a queue is backing up. |

--- a/patterns/10-microservices/distributed-tracing.md
+++ b/patterns/10-microservices/distributed-tracing.md
@@ -229,38 +229,47 @@ Do not reach for distributed tracing when any of the following hold.
 ## 6. ASCII structure diagram
 
 ```
-+------------------+        traceparent header        +------------------+
-|   API Gateway     |  --------------------------->    |  Auth Service     |
-|  (root span S1)   |   trace-id=T1, span-id=S1        |  (span S2,        |
-|                    |                                  |   parent=S1)      |
-+---------+----------+                                  +---------+--------+
-          |                                                        |
-          | trace-id=T1, span-id=S1                                | trace-id=T1
-          v                                                        v span-id=S2
-+------------------+                                    +------------------+
-|  Pricing Service  |                                    |  User Profile    |
-|  (span S3,        |                                    |  Service         |
-|   parent=S1)       |                                    | (span S4,        |
-+---------+----------+                                    |  parent=S2)      |
-          |                                               +---------+--------+
-          | trace-id=T1, span-id=S3                                |
-          v                                                        v
-+------------------+                                    +------------------+
-| Inventory Service |                                    |  Cache            |
-| (span S5,          |                                    | (span S6,         |
-|  parent=S3)         |                                    |  parent=S4)        |
-+--------------------+                                    +--------------------+
++----------------------------+
+| API Gateway (root span S1) |
++----------------------------+
+     | traceparent header, trace-id=T1, span-id=S1
+     v
++-----------------------------------+
+| Auth Service (span S2, parent=S1) |
++-----------------------------------+
+     | trace-id=T1, span-id=S2
+     v
++-------------------------------------------+
+| User Profile Service (span S4, parent=S2) |
++-------------------------------------------+
+     |
+     v
++----------------------------+
+| Cache (span S6, parent=S4) |
++----------------------------+
 
-All spans share one Trace ID, T1. Each span records its own Span ID and its
-parent's Span ID, so the tree above is reconstructed purely from that data
-once every span reaches the collector.
+API Gateway also starts a second branch directly:
 
-    Collector / trace backend
-    +-----------------------------------------------------+
-    |  T1  root S1 -> S2 -> S4 -> S6                       |
-    |             \-> S3 -> S5                              |
-    |  reconstructed timeline, per-span duration, status    |
-    +-----------------------------------------------------+
++--------------------------------------+
+| Pricing Service (span S3, parent=S1) |
++--------------------------------------+
+     | trace-id=T1, span-id=S3
+     v
++----------------------------------------+
+| Inventory Service (span S5, parent=S3) |
++----------------------------------------+
+
+All spans share one Trace ID, T1. Each span records its
+own Span ID and its parent's Span ID, so the tree above
+is reconstructed purely from that data once every span
+reaches the collector.
+
++---------------------------------------------------+
+| Collector / trace backend                         |
+| T1  root S1 -> S2 -> S4 -> S6                     |
+|             -> S3 -> S5                           |
+| reconstructed timeline, per-span duration, status |
++---------------------------------------------------+
 ```
 
 ## 7. Dynamics

--- a/patterns/10-microservices/remote-procedure-invocation.md
+++ b/patterns/10-microservices/remote-procedure-invocation.md
@@ -196,33 +196,45 @@ than one instance per service.
 ## 6. ASCII structure diagram
 
 ```
-+------------------+                          +------------------+
-|      Client       |                          |      Server      |
-|  (calling code)   |                          | (service impl.)  |
-+---------+----------+                          +----------+-------+
-          |                                                 ^
-          | in-process call                                 | in-process call
-          v                                                 |
-+------------------+                          +------------------+
-|   Client Stub     |                          |   Server Stub    |
-| (generated proxy) |                          | (generated skel) |
-+---------+----------+                          +----------+-------+
-          |  serialize request                             ^  deserialize request
-          |  (protobuf, thrift, JSON)                       |  serialize response
-          v                                                 |
-   +--------------+       wire protocol            +--------------+
-   |  Network I/O  |<---- HTTP/1.1, HTTP/2, --------|  Network I/O |
-   |  (transport)  |      TCP, TLS                  | (transport)  |
-   +--------------+                                 +--------------+
++-----------------------+
+| Client (calling code) |
++-----------------------+
+     | in-process call
+     v
++-------------------------------+
+| Client Stub (generated proxy) |
++-------------------------------+
+     | serialize request (protobuf, thrift, JSON)
+     v
++-------------------------+
+| Network I/O (transport) |
++-------------------------+
+     | wire protocol, HTTP/1.1, HTTP/2, TCP, TLS
+     v
++-------------------------+
+| Network I/O (transport) |
++-------------------------+
+     | deserialize request
+     v
++----------------------------------+
+| Server Stub (generated skeleton) |
++----------------------------------+
+     | in-process call
+     v
++---------------------------------+
+| Server (service implementation) |
++---------------------------------+
 
-                +--------------------------+
-                |     Service Registry      |
-                |  (resolves logical name    |
-                |   -> live network address) |
-                +--------------------------+
-                        ^              ^
-                        | consulted by |
-                Client Stub        Server (registers on start)
+The response returns serialized back through the same
+chain in reverse.
+
++-----------------------------------------------+
+| Service Registry                              |
+| resolves logical name to live network address |
++-----------------------------------------------+
+
+Consulted by Client Stub before each call. Server
+registers itself on start.
 ```
 
 ## 7. Dynamics

--- a/patterns/11-domain-driven-design/README.md
+++ b/patterns/11-domain-driven-design/README.md
@@ -2,7 +2,7 @@
 
 Origin. Evans, Vernon
 
-35 entries, 264,744 words. Every entry carries all 18
+35 entries, 264,811 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Anti-pattern
@@ -21,7 +21,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
-| [Event Storming](event-storming.md) | established | 8,206 | A team is about to build software for a business domain nobody on the team fully understands alone. |
+| [Event Storming](event-storming.md) | established | 8,210 | A team is about to build software for a business domain nobody on the team fully understands alone. |
 | [Process Manager](process-manager.md) | canonical | 8,296 | A business process spans more than one service, more than one aggregate, or more than one external system, and it cannot complete in a single local transaction. |
 
 ## Domain-Driven Design
@@ -36,7 +36,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Module](module.md) | canonical | 7,323 | A domain model that stays in one undifferentiated pile of classes becomes unreadable long before it becomes incorrect. |
 | [Repository](repository.md) | canonical | 6,776 | A domain layer needs to load and save the objects it works with, but the code that expresses business rules should not know whether an order lives in PostgreSQL, in a document ... |
 | [Specification](specification.md) | canonical | 7,066 | A domain accumulates rules that decide whether an object qualifies for something. |
-| [Value Object](value-object.md) | canonical | 7,547 | A domain model accumulates concepts that are not things, they are measurements, descriptions, or quantities. |
+| [Value Object](value-object.md) | canonical | 7,610 | A domain model accumulates concepts that are not things, they are measurements, descriptions, or quantities. |
 
 ## Domain-Driven Design, Strategic
 

--- a/patterns/11-domain-driven-design/README.md
+++ b/patterns/11-domain-driven-design/README.md
@@ -2,7 +2,7 @@
 
 Origin. Evans, Vernon
 
-35 entries, 264,620 words. Every entry carries all 18
+35 entries, 264,687 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Anti-pattern
@@ -21,7 +21,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
-| [Event Storming](event-storming.md) | established | 8,206 | A team is about to build software for a business domain nobody on the team fully understands alone. |
+| [Event Storming](event-storming.md) | established | 8,210 | A team is about to build software for a business domain nobody on the team fully understands alone. |
 | [Process Manager](process-manager.md) | canonical | 8,296 | A business process spans more than one service, more than one aggregate, or more than one external system, and it cannot complete in a single local transaction. |
 
 ## Domain-Driven Design
@@ -36,7 +36,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Module](module.md) | canonical | 7,280 | A domain model that stays in one undifferentiated pile of classes becomes unreadable long before it becomes incorrect. |
 | [Repository](repository.md) | canonical | 6,776 | A domain layer needs to load and save the objects it works with, but the code that expresses business rules should not know whether an order lives in PostgreSQL, in a document ... |
 | [Specification](specification.md) | canonical | 7,066 | A domain accumulates rules that decide whether an object qualifies for something. |
-| [Value Object](value-object.md) | canonical | 7,547 | A domain model accumulates concepts that are not things, they are measurements, descriptions, or quantities. |
+| [Value Object](value-object.md) | canonical | 7,610 | A domain model accumulates concepts that are not things, they are measurements, descriptions, or quantities. |
 
 ## Domain-Driven Design, Strategic
 

--- a/patterns/11-domain-driven-design/event-storming.md
+++ b/patterns/11-domain-driven-design/event-storming.md
@@ -264,35 +264,34 @@ than classes and interfaces.
 ## 6. ASCII structure diagram
 
 ```
-  TIMELINE (left = earlier, right = later)
-  --------------------------------------------------------------->
+TIMELINE, earlier to later, read top to bottom
 
-  [Actor]      [Command]        [Aggregate]      [Domain Event]
-  Customer  -->  PlaceOrder --> OrderAggregate --> OrderPlaced
-  (yellow)       (blue)         (yellow/tan)        (orange)
-                                                        |
-                                                        v
-                                                    [Policy]
-                                              "whenever OrderPlaced,
-                                               then ReserveStock"
-                                                     (lilac)
-                                                        |
-                                                        v
-  [External Sys]                              [Command]
-  Warehouse   <-------------------------------  ReserveStock
-  (pink)                                          (blue)
-                                                        |
-                                                        v
-                                              [Aggregate]      [Domain Event]
-                                              StockAggregate --> StockReserved
-                                              (yellow/tan)         (orange)
-                                                                       |
-                                                                       v
-                                                                  [Hotspot]
-                                                              "what happens if
-                                                               stock runs out
-                                                               mid-order?"
-                                                                (red, unresolved)
+[Actor] Customer (yellow)
+     |
+     v
+[Command] PlaceOrder (blue)
+     |
+     v
+[Aggregate] OrderAggregate (yellow/tan)
+     |
+     v
+[Domain Event] OrderPlaced (orange)
+     |
+     v
+[Policy] whenever OrderPlaced, then ReserveStock (lilac)
+     |
+     v
+[Command] ReserveStock (blue)
+     |
+     +---> [External Sys] Warehouse (pink)
+     v
+[Aggregate] StockAggregate (yellow/tan)
+     |
+     v
+[Domain Event] StockReserved (orange)
+     |
+     v
+[Hotspot] "what happens if stock runs out mid-order?" (red, unresolved)
 ```
 
 ## 7. Dynamics

--- a/patterns/11-domain-driven-design/value-object.md
+++ b/patterns/11-domain-driven-design/value-object.md
@@ -209,27 +209,34 @@ invariants.
 ## 6. ASCII structure diagram
 
 ```
-+----------------------+          holds / compares
-|   Client (Entity or   |------------------------------+
-|   Aggregate or        |                               |
-|   another Value Object|                               v
-+----------------------+                       +-----------------------+
-                                                |     Value Object      |
-                                                |------------------------|
-                                                | - attribute1: Type    |
-                                                | - attribute2: Type    |
-                                                |------------------------|
-                                                | + equals(other): bool |
-                                                | + hashCode(): int     |
-                                                | + withX(x): ValueObj  |
-                                                +-----------------------+
-                                                          ^
-                                                          | constructs, validates
-                                                          |
-                                                +-----------------------+
-                                                |   Factory (optional)  |
-                                                | + of(raw...): ValueObj|
-                                                +-----------------------+
++-----------------------------------------------------+
+| Client (Entity, Aggregate, or another Value Object) |
++-----------------------------------------------------+
+     | holds / compares
+     v
++-----------------------+
+| Value Object          |
+| - attribute1: Type    |
+| - attribute2: Type    |
+| + equals(other): bool |
+| + hashCode(): int     |
+| + withX(x): ValueObj  |
++-----------------------+
+     ^ constructs, validates
+     |
++------------------------+
+| Factory (optional)     |
+| + of(raw...): ValueObj |
++------------------------+
+
+No arrow in this diagram points from the Value Object
+back to a database row, a registry, or any store of
+the one true instance. Any number of equal instances
+may exist simultaneously in memory, and none of them
+is more authoritative than any other. This is the
+structural feature that most sharply distinguishes
+this diagram from an Entity's, where a repository or
+identity map is a required participant.
 ```
 
 No arrow in this diagram points from the Value Object back to a database row,

--- a/patterns/16-functional/README.md
+++ b/patterns/16-functional/README.md
@@ -2,7 +2,7 @@
 
 Origin. Category theory in practice
 
-39 entries, 240,732 words. Every entry carries all 18
+39 entries, 240,728 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Composition
@@ -31,7 +31,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
-| [Validation Applicative](validation-applicative.md) | canonical | 4,681 | A form, a configuration file, or an API request body carries several independent fields, and each field has its own validation rule, a required field, a numeric range, a format ... |
+| [Validation Applicative](validation-applicative.md) | canonical | 4,677 | A form, a configuration file, or an API request body carries several independent fields, and each field has its own validation rule, a required field, a numeric range, a format ... |
 
 ## Functional
 

--- a/patterns/16-functional/validation-applicative.md
+++ b/patterns/16-functional/validation-applicative.md
@@ -151,29 +151,31 @@ Validation and a fail-fast Either.
 ## 6. ASCII structure diagram
 
 ```
-    Validation, two constructors
+Validation, two constructors
 
-    Success v          holds a value v on the happy path
-    Failure e          holds an accumulated error value e
+  Success v   holds a value v on the happy path
+  Failure e   holds an accumulated error value e
 
-    Applicative apply, combining two Validation values
+Applicative apply, combining two Validation values
 
-    Success f  applied to  Success x   ->  Success (f x)
-    Success f  applied to  Failure e2  ->  Failure e2
-    Failure e1 applied to  Success x   ->  Failure e1
-    Failure e1 applied to  Failure e2  ->  Failure (e1 <> e2)
-                                                     ^^^^^^^^
-                                            combine, both errors kept
+  Success f  x Success x  -> Success (f x)
+  Success f  x Failure e2 -> Failure e2
+  Failure e1 x Success x  -> Failure e1
+  Failure e1 x Failure e2 -> Failure (e1 <> e2)
+                             ^^ combine, both errors kept
 
-    Three independent field checks combined with map3
+Three independent field checks combined with map3
 
-    checkName(input)   ---> Success "Ada"     or  Failure ["name required"]
-    checkAge(input)    ---> Success 34        or  Failure ["age must be positive"]
-    checkEmail(input)  ---> Success "a@b.com" or  Failure ["invalid email"]
+  checkName(input)
+    -> Success "Ada" or Failure ["name required"]
+  checkAge(input)
+    -> Success 34 or Failure ["age must be positive"]
+  checkEmail(input)
+    -> Success "a@b.com" or Failure ["invalid email"]
 
-    map3(checkName, checkAge, checkEmail, makeUser)
-       all three Success  ->  Success (makeUser "Ada" 34 "a@b.com")
-       any Failures       ->  Failure (every failing message combined)
+  map3(checkName, checkAge, checkEmail, makeUser)
+    all three Success -> Success (makeUser name age email)
+    any Failures      -> Failure (every failing msg combined)
 ```
 
 ## 7. Dynamics

--- a/patterns/18-anti-patterns/README.md
+++ b/patterns/18-anti-patterns/README.md
@@ -2,7 +2,7 @@
 
 Origin. Brown et al, AntiPatterns
 
-51 entries, 398,662 words. Every entry carries all 18
+51 entries, 398,620 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Anti-Pattern
@@ -45,7 +45,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
-| [Anemic Domain Model](anemic-domain-model.md) | canonical | 8,622 | A codebase reaches for persistence early. |
+| [Anemic Domain Model](anemic-domain-model.md) | canonical | 8,580 | A codebase reaches for persistence early. |
 | [Big Ball of Mud](big-ball-of-mud.md) | canonical | 9,287 | A reader can recognize this problem without ever hearing the pattern's name. |
 | [Boat Anchor](boat-anchor.md) | established | 7,077 | A team adds a piece of code, an API, a dependency, a database table, a configuration flag, or a whole service for a reason that was real at the time. |
 | [Circular Dependency](circular-dependency.md) | canonical | 9,330 | A codebase grows by adding files, packages, or services, and each new unit imports whatever it needs from its neighbours. |

--- a/patterns/18-anti-patterns/anemic-domain-model.md
+++ b/patterns/18-anti-patterns/anemic-domain-model.md
@@ -239,50 +239,50 @@ by the role they fail to play is the clearest way to see the shape.
 ## 6. ASCII structure diagram
 
 ```
-   ANEMIC SHAPE (the anti-pattern)
+ANEMIC SHAPE, the anti-pattern
 
-   +-----------------------+      reads/writes      +-----------------------+
-   |   OrderService        | ----------------------> |   Order (Data Holder)|
-   |------------------------|      every field       |------------------------|
-   | + placeOrder(order)   |      via getters/       | - id                  |
-   | + cancelOrder(order)  |      setters, no        | - lineItems           |
-   | + addLineItem(order,  |      encapsulation      | - status              |
-   |     item)             |      enforced by Order  | - total               |
-   | + recalculateTotal(   |                         | + getId()             |
-   |     order)            |                         | + getLineItems()      |
-   +-----------------------+                         | + setLineItems(list)  |
-              ^                                       | + getStatus()         |
-              |  called by                             | + setStatus(status)   |
-              |                                        | + getTotal()          |
-   +-----------------------+                          | + setTotal(amount)    |
-   |   OrderController      |                          +-----------------------+
-   |   BatchJob              |                                     ^
-   |   AnyOtherCaller        |----------------------------------- direct field
-   +-----------------------+          mutation, bypassing               access,
-                                       OrderService entirely,            no rule
-                                       nothing prevents it                enforced
++-----------------+
+| OrderController |
+| BatchJob        |
+| AnyOtherCaller  |
++-----------------+
+     | called by
+     v
++----------------------------+
+| OrderService               |
+| + placeOrder(order)        |
+| + cancelOrder(order)       |
+| + addLineItem(order, item) |
+| + recalculateTotal(order)  |
++----------------------------+
+     | reads/writes every field via getters/setters,
+     | no encapsulation enforced by Order
+     v
++-----------------------------------------------+
+| Order (Data Holder)                           |
+| - id                                          |
+| - lineItems                                   |
+| - status                                      |
+| - total                                       |
+| + getId(), getLineItems(), setLineItems(list) |
+| + getStatus(), setStatus(status)              |
+| + getTotal(), setTotal(amount)                |
++-----------------------------------------------+
 
+Any caller can also mutate a field directly, bypassing
+OrderService entirely, since no rule is enforced.
 
-   RICH ALTERNATIVE (what dimension 14 refactors toward)
+RICH ALTERNATIVE, what dimension 14 refactors toward
 
-   +-----------------------+
-   |   Order (Rich Entity) |
-   |------------------------|
-   | - id                   |
-   | - lineItems  (private) |
-   | - status     (private) |
-   |------------------------|
-   | + addLineItem(item)    |  <- enforces: cannot add after shipped
-   | + cancel()             |  <- enforces: cannot cancel after shipped
-   | + total(): Money       |  <- always derived, never a stale field
-   +-----------------------+
-              ^
-              | calls only the public, invariant-preserving methods
-              |
-   +-----------------------+
-   |   OrderController      |
-   |   BatchJob              |
-   +-----------------------+
++---------------------------------------------------+
+| Order (Rich Entity)                               |
+| - id                                              |
+| - lineItems  (private)                            |
+| - status     (private)                            |
+| + addLineItem(item)   enforces: not after shipped |
+| + cancel()            enforces: not after shipped |
+| + total(): Money      always derived, never stale |
++---------------------------------------------------+
 ```
 
 ## 7. Dynamics


### PR DESCRIPTION
## Summary

- Redraws ten more ASCII diagrams that exceeded 78 characters wide,
  the next tier at 81 to 82 characters, down to 52 to 71 characters.
- validation-applicative.md, anemic-domain-model.md,
  move-function.md, event-driven-architecture.md, pipes-filters.md,
  business-delegate.md, distributed-tracing.md,
  remote-procedure-invocation.md, event-storming.md,
  value-object.md.
- No structural, prose, reference, or code content changed. Only the
  diagram fences.
- tools/gen-indexes.py was re-run before this commit, regenerating the
  seven family index tables these entries span.

## Notable redesigns

- event-driven-architecture.md's single diagram fence actually covers
  three distinct architectural styles in sequence, event notification
  plus event-carried state transfer, event sourcing, and CQRS. All
  three are redrawn and none of the four consumer fan-out, the derived
  event, or the read/write model split was dropped.
- distributed-tracing.md's two-branch trace tree (Auth to User Profile
  to Cache, and Pricing to Inventory) is now a vertical chain with the
  second branch clearly marked as starting from the same root span,
  plus the collector's reconstructed timeline preserved verbatim.
- event-storming.md's full color-coded sticky-note sequence, actor
  through command through aggregate through domain event through
  policy through external system through hotspot, reads top to bottom
  with every color annotation intact.

## Test plan

- [x] check-structure.py, 884 of 884 entries pass
- [x] check-prose.py, 925 of 925 entries pass
- [x] markdownlint-cli2 0.23.2, 0 issues on the ten changed files
- [x] validate-refs.py --strict, every citation resolves
- [x] check-code.py --strict, 2826 compiled, 0 failed, 0 skipped
- [x] gen-indexes.py re-run, seven family README tables regenerated
      and committed alongside the content changes
- [x] git diff --stat -- docs and dist and the root README.md, all
      empty, no unexpected top level changes

37 more entries with the same width issue remain, to be worked through
in following batches.
