### PR TITLE
fix(patterns) redraw ten more ASCII diagrams under 78 columns

### DIFF
--- a/patterns/01-design-patterns-gof/README.md
+++ b/patterns/01-design-patterns-gof/README.md
@@ -2,7 +2,7 @@
 
 Origin. Gamma, Helm, Johnson, Vlissides 1994
 
-32 entries, 306,354 words, 1 more planned, 33 total when the family is complete. Every entry carries all 18
+32 entries, 306,348 words, 1 more planned, 33 total when the family is complete. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Behavioral
@@ -15,7 +15,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Iterator](iterator.md) | canonical | 11,672 | A client needs to visit every element of a collection, and the collection knows how it stores those elements while the client does not and should not. |
 | [Mediator](mediator.md) | canonical | 11,878 | A set of objects has to cooperate, and every one of them needs to know something about the others in order to do its part. |
 | [Memento](memento.md) | canonical | 11,628 | An object holds state that changes over time, and something outside that object needs the ability to put the state back the way it was. |
-| [Observer](observer.md) | canonical | 13,321 | A piece of state changes, and an unknown number of other pieces of the system need to react. |
+| [Observer](observer.md) | canonical | 13,315 | A piece of state changes, and an unknown number of other pieces of the system need to react. |
 | [Servant](servant.md) | contested | 5,677 | Wikipedia's own definition, quoted directly. |
 | [State](state.md) | canonical | 14,281 | An object behaves differently depending on a mode it is in, and every method that depends on that mode has grown the same conditional. |
 | [Strategy](strategy.md) | canonical | 11,071 | An object does a piece of work in more than one way, and the choice of way is not a property of the object's identity. |

--- a/patterns/01-design-patterns-gof/observer.md
+++ b/patterns/01-design-patterns-gof/observer.md
@@ -286,28 +286,43 @@ leak possible, and the two facts are the same fact.
 ## 6. ASCII structure diagram
 
 ```
-   +--------------------------------+          +----------------------+
-   |            Subject             |   holds  |       Observer       |
-   |--------------------------------|  0..*    |----------------------|
-   | - observers: List<Observer>    |--------->| + update(subject?)   |
-   | + attach(o): Registration      |          +----------------------+
-   | + detach(reg)                  |                     ^        ^
-   | # notify()                     |                     |        |
-   +--------------------------------+                     |        |
-                  ^                                       |        |
-                  | extends                    implements |        | implements
-                  |                                       |        |
-   +--------------------------------+          +--------------------+---------+
-   |        ConcreteSubject         |  reads   | ConcreteObserverA  | ...B     |
-   |--------------------------------|<- - - - -|--------------------|----------|
-   | - state: State                 |  (pull)  | - subject: ref     | - cache  |
-   | + getState(): State            |          | + update(...)      | + update |
-   | + setState(s)  -> notify()     |          +--------------------+----------+
-   +--------------------------------+
++-----------------------------+
+| Subject                     |
+| - observers: List<Observer> |
+| + attach(o): Registration   |
+| + detach(reg)               |
+| # notify()                  |
++-----------------------------+
+     | holds 0..*
+     v
++--------------------+
+| Observer           |
+| + update(subject?) |
++--------------------+
 
-   Solid arrow  = compile time dependency.
-   Dashed arrow = the pull model back reference. Absent in the push model.
-   The Registration returned by attach() is the only thing that can detach.
++----------------------------------+
+| ConcreteSubject, extends Subject |
+| - state: State                   |
+| + getState(): State              |
+| + setState(s) -> notify()        |
++----------------------------------+
+     | reads (pull), dashed back reference
+     v
++----------------------------------------+
+| ConcreteObserverA, implements Observer |
+| - subject: ref                         |
+| + update(...)                          |
++----------------------------------------+
++----------------------------------------+
+| ConcreteObserverB, implements Observer |
+| - cache                                |
+| + update                               |
++----------------------------------------+
+
+Solid arrow means a compile-time dependency. Dashed
+arrow is the pull model's back reference, absent in the
+push model. The Registration returned by attach() is
+the only thing that can detach.
 ```
 
 ## 7. Dynamics

--- a/patterns/02-code-smells/README.md
+++ b/patterns/02-code-smells/README.md
@@ -2,7 +2,7 @@
 
 Origin. Fowler and Beck, Refactoring
 
-28 entries, 221,153 words. Every entry carries all 18
+28 entries, 221,119 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Bloaters
@@ -11,7 +11,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 |---|---|---|---|
 | [Data Clumps](data-clumps.md) | canonical | 5,832 | The smell shows up first in method signatures. |
 | [Duplicate Code](duplicate-code.md) | canonical | 8,029 | The same idea is written down twice, or more, in a codebase, so that changing the idea means finding and editing every copy. |
-| [Large Class](large-class.md) | canonical | 9,844 | A class keeps absorbing new fields and new methods until it is doing the job of what should have been five or six separate collaborators. |
+| [Large Class](large-class.md) | canonical | 9,817 | A class keeps absorbing new fields and new methods until it is doing the job of what should have been five or six separate collaborators. |
 | [Lazy Class](lazy-class.md) | canonical | 7,708 | A codebase accretes classes over time for reasons that have nothing to do with present-day need. |
 | [Long Method](long-method.md) | canonical | 7,675 | A method starts small. It does one clear thing, and its name says what that thing is. |
 
@@ -28,7 +28,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
 | [Comments](comments.md) | canonical | 8,795 | A comment is a message from one point in time to a later reader, and it is never checked by anything that runs. |
-| [Dead Code](dead-code.md) | canonical | 9,473 | Dead code accumulates as an ordinary, unavoidable byproduct of change. |
+| [Dead Code](dead-code.md) | canonical | 9,466 | Dead code accumulates as an ordinary, unavoidable byproduct of change. |
 | [Long Parameter List](long-parameter-list.md) | canonical | 7,502 | A function, method, or constructor accumulates parameters over its lifetime, usually one at a time, usually each addition individually reasonable, until the call site becomes ... |
 | [Loops](loops.md) | canonical | 8,826 | A loop is the most flexible construct available in an imperative language. |
 | [Middle Man](middle-man.md) | canonical | 7,237 | The smell shows up during evolution, almost never at the moment a class is first written. |

--- a/patterns/02-code-smells/dead-code.md
+++ b/patterns/02-code-smells/dead-code.md
@@ -270,41 +270,46 @@ indistinguishable, to the next reader, from a claim that happens to be wrong.
 ## 6. ASCII structure diagram
 
 ```
-                        REACHABILITY GRAPH
-                        ===================
+REACHABILITY GRAPH
 
-  entry points                 live subgraph            dead subgraph
-  -------------                --------------            -------------
+Entry points: main(), httpRoute /orders, cronJob nightly
 
-  main() ----+                 +--> handleOrder()        applyLegacyDiscount()
-             |                 |         |                    (no incoming edge
-  httpRoute  +---> dispatch() -+--> applyTax()                 from any entry
-  /orders                      |         |                     point below)
-             |                 +--> validate()
-  cronJob    |
-  nightly    +---> reconcile()-+--> readLedger()          [dead subgraph has
-                                |                            zero paths back
-                                +--> writeLedger()           to any entry point]
+main() and httpRoute /orders both call dispatch(), which
+calls:
+  handleOrder()
+  applyTax()
+  validate()
+
+cronJob nightly calls reconcile(), which calls:
+  readLedger()
+  writeLedger()
+
+This is the live subgraph, every function above has a path
+back to an entry point.
+
+Dead subgraph: applyLegacyDiscount(). No incoming edge from
+any entry point above, zero paths back to any entry point.
 
 
-                        GUARD-GATED BRANCH
-                        ===================
+GUARD-GATED BRANCH
 
-  process(order)
-       |
-       v
-  +---------------------------+
-  | if legacyFlag.isEnabled() |   <-- legacyFlag hardcoded false
-  |     doLegacyPath(order)   |       in every environment since
-  | else                      |       the rollout finished
-  |     doCurrentPath(order)  |
-  +---------------------------+
-         |             |
-         v             v
-   doLegacyPath   doCurrentPath   <-- structurally reachable,
-   (dead: guard   (live: the      practically dead, needs the
-    never true)    only path      guard's known value as evidence,
-                    taken)        not the call graph alone
+process(order)
+     |
+     v
+if legacyFlag.isEnabled():
+    doLegacyPath(order)
+else:
+    doCurrentPath(order)
+
+legacyFlag is hardcoded false in every environment since the
+rollout finished.
+
+doLegacyPath: dead, guard never true.
+doCurrentPath: live, the only path actually taken.
+
+doLegacyPath is structurally reachable but practically dead,
+needs the guard's known value as evidence, not the call
+graph alone.
 ```
 
 ## 7. Dynamics

--- a/patterns/02-code-smells/large-class.md
+++ b/patterns/02-code-smells/large-class.md
@@ -275,46 +275,51 @@ to update in the same commit that performs the split.
 ## 6. ASCII structure diagram
 
 ```
-Before, one class, several unrelated responsibility clusters:
+Before, one class, several unrelated responsibility
+clusters:
 
-+--------------------------------------------------+
-|                   Order                           |
-|----------------------------------------------------|
-| - lineItems, customerId, discountCode              |  cluster A: pricing
-| - taxRate, currency                                 |
-| - shippingAddress, billingAddress                  |  cluster B: fulfillment
-| - trackingNumber, carrier                           |
-| - emailTemplate, smtpConfig                         |  cluster C: notification
-| - auditLog                                          |  cluster D: audit
-|----------------------------------------------------|
-| + calculateSubtotal()                               |  cluster A methods
-| + applyDiscount()                                    |
-| + calculateTax()                                     |
-| + scheduleShipment()                                 |  cluster B methods
-| + assignCarrier()                                    |
-| + sendConfirmationEmail()                             |  cluster C methods
-| + sendShippingNotice()                                |
-| + recordAuditEntry()                                  |  cluster D methods
-+--------------------------------------------------+
++---------------------------------------------+
+| Order                                       |
+| cluster A, pricing: lineItems, customerId,  |
+| discountCode, taxRate, currency             |
+| cluster B, fulfillment: shippingAddress,    |
+| billingAddress, trackingNumber, carrier     |
+| cluster C, notification: emailTemplate,     |
+| smtpConfig                                  |
+| cluster D, audit: auditLog                  |
+|                                             |
+| cluster A methods: calculateSubtotal(),     |
+| applyDiscount(), calculateTax()             |
+| cluster B methods: scheduleShipment(),      |
+| assignCarrier()                             |
+| cluster C methods: sendConfirmationEmail(), |
+| sendShippingNotice()                        |
+| cluster D methods: recordAuditEntry()       |
++---------------------------------------------+
 
-After, Extract Class applied per cluster, Original Class delegates:
+After, Extract Class applied per cluster, Original
+Class delegates:
 
-  +--------------+     uses      +-------------------+
-  |    Order     | ------------> |    OrderPricer     |
-  | (core state) |               | (cluster A logic)  |
-  +--------------+               +-------------------+
-        |    uses       +-------------------------+
-        +--------------> |   ShipmentScheduler      |
-        |                | (cluster B logic)        |
-        |                +-------------------------+
-        |    uses       +-------------------------+
-        +--------------> |   OrderNotifier           |
-        |                | (cluster C logic)        |
-        |                +-------------------------+
-        |    uses       +-------------------------+
-        +--------------> |   OrderAuditLog           |
-                         | (cluster D logic)        |
-                         +-------------------------+
++--------------------+
+| Order (core state) |
++--------------------+
+     | uses
+     v
++-------------------------------+
+| OrderPricer (cluster A logic) |
++-------------------------------+
++-------------------------------------+
+| ShipmentScheduler (cluster B logic) |
++-------------------------------------+
++---------------------------------+
+| OrderNotifier (cluster C logic) |
++---------------------------------+
++---------------------------------+
+| OrderAuditLog (cluster D logic) |
++---------------------------------+
+
+Order uses all four, each handling one cluster's
+logic.
 ```
 
 ## 7. Dynamics

--- a/patterns/05-architectural/README.md
+++ b/patterns/05-architectural/README.md
@@ -2,7 +2,7 @@
 
 Origin. Buschmann POSA 1, Bass SEI
 
-31 entries, 248,947 words. Every entry carries all 18
+31 entries, 248,931 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Architectural
@@ -30,7 +30,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Multi-Tenant Architecture](multi-tenant-architecture.md) | canonical | 5,015 | A SaaS provider serves many customers, called tenants, from one running application. |
 | [Onion Architecture](onion-architecture.md) | canonical | 8,637 | A team builds a business application against a specific database, a specific web framework, and a specific set of third party integrations, because those are the concrete ... |
 | [Peer-to-Peer](peer-to-peer.md) | canonical | 8,950 | A system needs many participants to exchange data or share work, and at least one of the following forces makes a single, dedicated server the wrong place to put that coordination. |
-| [Pipeline Architecture](pipeline-architecture.md) | canonical | 8,757 | A system needs to transform a stream of data through a sequence of independent processing steps, and the set of steps, their order, or their implementation is expected to change ... |
+| [Pipeline Architecture](pipeline-architecture.md) | canonical | 8,741 | A system needs to transform a stream of data through a sequence of independent processing steps, and the set of steps, their order, or their implementation is expected to change ... |
 | [Pipes and Filters](pipes-filters.md) | canonical | 7,870 | A system must transform a stream of data through several independent processing steps, and the set of steps, their order, or the data source itself is expected to change over the ... |
 | [Plugin Architecture](plugin-architecture.md) | canonical | 7,823 | An application needs to support a set of behaviours that is open-ended, unknown at the time the core is built, and likely to be supplied by parties who are not the core's own ... |
 | [Plugin Sandbox](plugin-sandbox.md) | established | 10,826 | A host application defines an extension point, using Plugin Architecture or Microkernel, so that its behavior can grow without every new feature being merged into the core ... |

--- a/patterns/05-architectural/README.md
+++ b/patterns/05-architectural/README.md
@@ -2,7 +2,7 @@
 
 Origin. Buschmann POSA 1, Bass SEI
 
-31 entries, 248,953 words. Every entry carries all 18
+31 entries, 248,937 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Architectural
@@ -30,7 +30,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Multi-Tenant Architecture](multi-tenant-architecture.md) | canonical | 5,015 | A SaaS provider serves many customers, called tenants, from one running application. |
 | [Onion Architecture](onion-architecture.md) | canonical | 8,637 | A team builds a business application against a specific database, a specific web framework, and a specific set of third party integrations, because those are the concrete ... |
 | [Peer-to-Peer](peer-to-peer.md) | canonical | 8,950 | A system needs many participants to exchange data or share work, and at least one of the following forces makes a single, dedicated server the wrong place to put that coordination. |
-| [Pipeline Architecture](pipeline-architecture.md) | canonical | 8,757 | A system needs to transform a stream of data through a sequence of independent processing steps, and the set of steps, their order, or their implementation is expected to change ... |
+| [Pipeline Architecture](pipeline-architecture.md) | canonical | 8,741 | A system needs to transform a stream of data through a sequence of independent processing steps, and the set of steps, their order, or their implementation is expected to change ... |
 | [Pipes and Filters](pipes-filters.md) | canonical | 7,891 | A system must transform a stream of data through several independent processing steps, and the set of steps, their order, or the data source itself is expected to change over the ... |
 | [Plugin Architecture](plugin-architecture.md) | canonical | 7,823 | An application needs to support a set of behaviours that is open-ended, unknown at the time the core is built, and likely to be supplied by parties who are not the core's own ... |
 | [Plugin Sandbox](plugin-sandbox.md) | established | 10,826 | A host application defines an extension point, using Plugin Architecture or Microkernel, so that its behavior can grow without every new feature being merged into the core ... |

--- a/patterns/05-architectural/pipeline-architecture.md
+++ b/patterns/05-architectural/pipeline-architecture.md
@@ -271,29 +271,54 @@ survives in a variable called pipeline.
 ## 6. ASCII structure diagram
 
 ```
-  DATA SOURCE                                                  DATA SINK
-  (file, socket,                                             (file, socket,
-   queue, request)                                            queue, response)
-        |                                                            ^
-        v                                                            |
-  +-----------+     pipe     +-----------+     pipe     +-----------+
-  |  FILTER A |------------->|  FILTER B |------------->|  FILTER C |
-  | (e.g.     |   [buffer,   | (e.g.     |   [buffer,   | (e.g.     |
-  |  parse)   |   backpress] |  enrich)  |   backpress] |  encode)  |
-  +-----------+              +-----------+              +-----------+
-        ^                          ^                          ^
-        |                          |                          |
-   single input,             single input,               single input,
-   single output              single output               single output
-   (uniform contract          (uniform contract           (uniform contract
-    shared by every            shared by every             shared by every
-    filter in the chain)       filter in the chain)        filter in the chain)
++--------------------------------------------+
+| Data Source (file, socket, queue, request) |
++--------------------------------------------+
+     | single input/output uniform contract
+     v
++----------------------------+
+| Filter A, e.g. parse       |
+| pipe, buffer, backpressure |
++----------------------------+
+     |
+     v
++----------------------------+
+| Filter B, e.g. enrich      |
+| pipe, buffer, backpressure |
++----------------------------+
+     |
+     v
++-----------------------+
+| Filter C, e.g. encode |
++-----------------------+
+     |
+     v
++-------------------------------------------+
+| Data Sink (file, socket, queue, response) |
++-------------------------------------------+
 
-  Optional PUMP drives passive filters that have no thread of their own.
+Every filter shares the same uniform contract, single
+input, single output.
 
-  +------+   calls A(x)   +---+   calls B(A(x))   +---+   calls C(B(A(x)))
-  | PUMP |--------------->| A |------------------->| B |------------------>  out
-  +------+                +---+                    +---+
+Optional PUMP drives passive filters that have no
+thread of their own:
+
++------+
+| PUMP |
++------+
+     | calls A(x)
+     v
++---+
+| A |
++---+
+     | calls B(A(x))
+     v
++---+
+| B |
++---+
+     | calls C(B(A(x)))
+     v
+out
 ```
 
 ## 7. Dynamics

--- a/patterns/12-data-storage/README.md
+++ b/patterns/12-data-storage/README.md
@@ -2,7 +2,7 @@
 
 Origin. Kleppmann
 
-45 entries, 319,823 words. Every entry carries all 18
+45 entries, 319,776 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Concurrency Control
@@ -49,7 +49,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Lamport Clock](lamport-clock.md) | canonical | 6,460 | A distributed system has no shared memory and no shared clock. |
 | [Leaderless Replication](leaderless-replication.md) | canonical | 7,925 | A single-leader replicated database routes every write through one node. |
 | [Log Compaction](log-compaction.md) | established | 8,019 | An append-only log is the simplest and most dependable storage primitive a distributed system offers. |
-| [Medallion Architecture](medallion-architecture.md) | established | 7,094 | A data platform ingests information from many upstream systems. |
+| [Medallion Architecture](medallion-architecture.md) | established | 7,047 | A data platform ingests information from many upstream systems. |
 | [Multi-Leader Replication](multi-leader-replication.md) | established | 7,911 | A team runs a database that serves write traffic from more than one geographic region, or from more than one autonomous system that must keep working during a network partition ... |
 | [Multiversion Concurrency Control](mvcc.md) | canonical | 7,230 | A database serves many concurrent transactions. |
 | [Quorum](quorum.md) | canonical | 7,448 | A system replicates the same piece of data onto several nodes so that the loss of any one node, or the temporary unavailability of any one node, does not lose data or stop the ... |

--- a/patterns/12-data-storage/medallion-architecture.md
+++ b/patterns/12-data-storage/medallion-architecture.md
@@ -215,36 +215,41 @@ more physical tables in the same storage system.
 ## 6. ASCII structure diagram
 
 ```
-+------------------+       +------------------+       +------------------+
-|   SOURCE SYSTEMS  |       |                  |       |                  |
-|  ---------------- |       |                  |       |                  |
-|  OLTP database CDC|------>|                  |       |                  |
-|  Third party API  |------>|   BRONZE LAYER   |       |                  |
-|  Event stream      |------>|  raw, append only |       |                  |
-|  File upload       |------>|  source schema     |       |                  |
-+------------------+       |  ingestion metadata|       |                  |
-                            +---------+---------+       |                  |
-                                      |                  |                  |
-                            transform | clean, dedupe,   |                  |
-                            and       | validate, join   |                  |
-                            conform   |                  |                  |
-                                      v                  |                  |
-                            +------------------+         |                  |
-                            |   SILVER LAYER    |         |                  |
-                            |  conformed entity  |         |                  |
-                            |  validated, joined |-------->|                  |
-                            |  read by data sci  |         |                  |
-                            +---------+----------+         |                  |
-                                      |                    |                  |
-                            aggregate | business logic,     |                  |
-                            and shape | metric calc          |                  |
-                                      v                      v                  |
-                            +------------------+   +------------------+
-                            |    GOLD LAYER      |   |    CATALOG /      |
-                            |  business metrics   |<--|  LINEAGE STORE     |
-                            |  ML feature tables   |   |  schema, owner,    |
-                            |  read by BI, ML       |   |  access control    |
-                            +------------------+   +------------------+
++-------------------+
+| Source Systems    |
+| OLTP database CDC |
+| Third party API   |
+| Event stream      |
+| File upload       |
++-------------------+
+     |
+     v
++-----------------------------------------------------+
+| Bronze Layer                                        |
+| raw, append only, source schema, ingestion metadata |
++-----------------------------------------------------+
+     | transform and conform: clean, dedupe,
+     | validate, join
+     v
++-------------------------------------------------------+
+| Silver Layer                                          |
+| conformed entity, validated, joined, read by data sci |
++-------------------------------------------------------+
+     | aggregate and shape: business logic,
+     | metric calc
+     v
++-----------------------------------------------------+
+| Gold Layer                                          |
+| business metrics, ML feature tables, read by BI, ML |
++-----------------------------------------------------+
+
++-------------------------------+
+| Catalog / Lineage Store       |
+| schema, owner, access control |
++-------------------------------+
+
+The Catalog / Lineage Store also feeds into the Gold
+Layer, and is populated from the Silver Layer.
 ```
 
 ## 7. Dynamics

--- a/patterns/14-testing/README.md
+++ b/patterns/14-testing/README.md
@@ -2,7 +2,7 @@
 
 Origin. Meszaros, xUnit Test Patterns
 
-30 entries, 217,034 words. Every entry carries all 18
+30 entries, 217,028 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Test Data
@@ -19,7 +19,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Dummy](dummy.md) | canonical | 6,529 | A constructor, a factory function, or a method signature requires an argument of a particular type, but the code path being exercised by a specific test does not use that argument ... |
 | [Fake](fake.md) | canonical | 6,405 | A piece of code depends on a collaborator that is real, correct, and slow, or real, correct, and hard to set up. |
 | [Mock](mock.md) | canonical | 6,136 | A unit of code under test calls a method on a collaborator, and the whole reason the test exists is to prove that call happens, with the right arguments, in the right ... |
-| [Stub](stub.md) | canonical | 9,016 | Code under test frequently depends on something the test cannot, or should not, use as it really behaves. |
+| [Stub](stub.md) | canonical | 9,010 | Code under test frequently depends on something the test cannot, or should not, use as it really behaves. |
 
 ## Test Structure
 

--- a/patterns/14-testing/stub.md
+++ b/patterns/14-testing/stub.md
@@ -263,31 +263,31 @@ dimension 14.
 ## 6. ASCII structure diagram
 
 ```
-+-------------------+   constructs and   +----------------------+
-|     Test Case      |   injects a stub   |  System Under Test   |
-|---------------------|------------------->|----------------------|
-| arrange canned      |                    |  depends on --------->  Collaborator
-| values in setup     |                    |     (interface)      |
-+----------+----------+                    +----------+-----------+
-           |                                          ^
-           | constructs                               | implemented by,
-           v                                          | only during this
-+---------------------------+                          | test run
-|       Test Stub           |--------------------------+
-|----------------------------|
-| - canned answer(s), set    |
-|   by the test in arrange   |
-| + charge(amount): Result   |
-+---------------------------+
-           ^
-           | never queried
-           | or asserted upon
-           |
-   +-------------------------------------------+
-   | Test asserts only on the SUT's own return  |
-   | value or observable state, never on the    |
-   | Test Stub itself.                          |
-   +-------------------------------------------+
++--------------------------------+
+| Test Case                      |
+| arrange canned values in setup |
++--------------------------------+
+     | constructs
+     v
++------------------------------------------------+
+| Test Stub                                      |
+| - canned answer(s), set by the test in arrange |
+| + charge(amount): Result                       |
++------------------------------------------------+
+     ^ implemented by, only during this test run
+     |
+Test Case also constructs and injects the stub into:
+
++-------------------------------------+
+| System Under Test                   |
+| depends on Collaborator (interface) |
++-------------------------------------+
+
++-------------------------------------------------------+
+| Test asserts only on the SUT's own return value or    |
+| observable state, never on the Test Stub itself. The  |
+| Test Stub is never queried or asserted upon directly. |
++-------------------------------------------------------+
 ```
 
 ## 7. Dynamics

--- a/patterns/15-security/README.md
+++ b/patterns/15-security/README.md
@@ -2,7 +2,7 @@
 
 Origin. OWASP ASVS
 
-38 entries, 226,876 words. Every entry carries all 18
+38 entries, 226,886 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Authorization
@@ -50,7 +50,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Separation of Duties](separation-of-duties.md) | canonical | 6,652 | A system has operations where one trusted actor can cause damage and hide it. |
 | [Supply Chain SBOM](supply-chain-sbom.md) | established | 6,110 | A software artifact enters production with code from many origins. |
 | [Threat Modeling](threat-modeling.md) | established | 6,225 | A software team is making a design choice that changes who can reach which asset, what data crosses which boundary, what authority a component holds, or what a failed control ... |
-| [Token Binding and DPoP](token-binding-and-dpop.md) | established | 6,233 | Bearer tokens are convenient because a resource server can authorize a request by checking the token. |
+| [Token Binding and DPoP](token-binding-and-dpop.md) | established | 6,243 | Bearer tokens are convenient because a resource server can authorize a request by checking the token. |
 | [Token-based Authentication](token-based-authentication.md) | established | 7,183 | The problem appears when a system must authenticate repeated requests without asking the caller to resend a long-lived secret, such as a password, private key, or root cloud ... |
 | [Webhook Signature Verification](webhook-signature-verification.md) | established | 6,038 | A webhook endpoint receives requests from the public internet, usually without a browser session, an OAuth bearer token, or a mutual TLS client certificate. |
 | [Zero Trust](zero-trust.md) | established | 6,642 | A system has users, services, jobs, devices, and partners that need access to resources from many networks. |

--- a/patterns/15-security/token-binding-and-dpop.md
+++ b/patterns/15-security/token-binding-and-dpop.md
@@ -251,29 +251,47 @@ from the private key holder before accepting the token.
 
 ## 6. ASCII structure diagram
 
-```text
- +-------------------+        proof at token request       +-------------------+
- |    DPoP Client    |------------------------------------->| Authorization     |
- |-------------------|                                      | Server            |
- | private key       |<-------------------------------------|-------------------|
- | nonce cache       |       DPoP access token              | cnf.jkt issuer    |
- +---------+---------+                                      +---------+---------+
-           |                                                          |
-           | protected request                                        |
-           | Authorization: DPoP <token>                              |
-           | DPoP: <proof jwt>                                        |
-           v                                                          |
- +---------+---------+       token claims or introspection    +--------v--------+
- | Resource Server   |<-------------------------------------->| Token Metadata  |
- |-------------------|                                        | or JWKS         |
- | proof verifier    |                                        +-----------------+
- | binding checker   |
- | replay checker    |---- records jti, key, time ----------> +-----------------+
- +-------------------+                                        | Replay Store    |
-                                                              +-----------------+
+```
++-------------+
+| DPoP Client |
+| private key |
+| nonce cache |
++-------------+
+     | proof at token request
+     v
++----------------------+
+| Authorization Server |
+| cnf.jkt issuer       |
++----------------------+
+     | returns a DPoP access token
+     v
+(client now holds the token, back to DPoP Client)
 
- The token says which public key is bound. The proof shows the caller holds
- the matching private key for this HTTP request.
+DPoP Client sends a protected request:
+  Authorization: DPoP <token>
+  DPoP: <proof jwt>
+
++-----------------+
+| Resource Server |
+| proof verifier  |
+| binding checker |
+| replay checker  |
++-----------------+
+     | token claims or introspection
+     v
++------------------------+
+| Token Metadata or JWKS |
++------------------------+
+
+Resource Server also records jti, key, time to:
+
++--------------+
+| Replay Store |
++--------------+
+
+The token says which public key is bound. The proof
+shows the caller holds the matching private key for
+this HTTP request.
 ```
 
 ## 7. Dynamics

--- a/patterns/16-functional/README.md
+++ b/patterns/16-functional/README.md
@@ -2,14 +2,14 @@
 
 Origin. Category theory in practice
 
-39 entries, 240,732 words. Every entry carries all 18
+39 entries, 240,728 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Composition
 
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
-| [Profunctor](profunctor.md) | canonical | 5,397 | A codebase accumulates two families of type constructors that look unrelated on the surface but are secretly the same shape. |
+| [Profunctor](profunctor.md) | canonical | 5,393 | A codebase accumulates two families of type constructors that look unrelated on the surface but are secretly the same shape. |
 
 ## Data and State
 

--- a/patterns/16-functional/README.md
+++ b/patterns/16-functional/README.md
@@ -2,7 +2,7 @@
 
 Origin. Category theory in practice
 
-39 entries, 240,728 words. Every entry carries all 18
+39 entries, 240,724 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Composition

--- a/patterns/16-functional/profunctor.md
+++ b/patterns/16-functional/profunctor.md
@@ -187,24 +187,29 @@ data, and both matter for optics.
 ## 6. ASCII structure diagram
 
 ```
-    Profunctor p, two type parameters, opposite variance
+Profunctor p, two type parameters, opposite variance
 
-    input side (contravariant)          output side (covariant)
-    c --------- f ---------> a          b --------- g ---------> d
-                                |                     ^
-                                v                     |
-                             p a b  ------ dimap f g ------>  p c d
+input side (contravariant)
+  c --- f ---> a
+output side (covariant)
+  b --- g ---> d
 
-    Base instance, functions:
+  p a b  --- dimap f g --->  p c d
 
-    p a b  =  a -> b
+Base instance, functions:
 
-    dimap f g h  =  g . h . f          (precompose f, run h, postcompose g)
+  p a b  =  a -> b
 
-    Subclass Strong (products):        Subclass Choice (sums):
+  dimap f g h  =  g . h . f
+    (precompose f, run h, postcompose g)
 
-    p a b  ---->  p (a, c) (b, c)      p a b  ---->  p (Either a c) (Either b c)
-    (focus one field, pass the rest)   (focus one branch, pass the other through)
+Subclass Strong (products):
+  p a b  ---->  p (a, c) (b, c)
+  (focus one field, pass the rest)
+
+Subclass Choice (sums):
+  p a b  ---->  p (Either a c) (Either b c)
+  (focus one branch, pass the other through)
 ```
 
 ## 7. Dynamics

--- a/patterns/17-ai-agentic/README.md
+++ b/patterns/17-ai-agentic/README.md
@@ -2,7 +2,7 @@
 
 Origin. Papers and vendor engineering, 2023 to 2026
 
-64 entries, 492,522 words, 1 more planned, 65 total when the family is complete. Every entry carries all 18
+64 entries, 492,513 words, 1 more planned, 65 total when the family is complete. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## AI Agentic
@@ -85,7 +85,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
 | [Agent Handoff](agent-handoff.md) | established | 8,432 | A team building an LLM-driven assistant for a domain with more than one kind of request quickly runs into a shape problem. |
-| [Hierarchical Agents](hierarchical-agents.md) | established | 9,783 | A single agent with a tool belt and a large context window handles a surprising amount of real work, and the correct starting point for almost any agentic system is exactly that ... |
+| [Hierarchical Agents](hierarchical-agents.md) | established | 9,774 | A single agent with a tool belt and a large context window handles a surprising amount of real work, and the correct starting point for almost any agentic system is exactly that ... |
 | [Orchestrator-Worker](orchestrator-worker.md) | established | 10,095 | A task arrives whose internal shape cannot be known until the model has already looked at it. |
 | [Sub-Agent Isolation](sub-agent-isolation.md) | established | 9,798 | An agent delegates a subtask to another agent, and the subtask involves work whose intermediate output the delegating agent will never need again. |
 

--- a/patterns/17-ai-agentic/hierarchical-agents.md
+++ b/patterns/17-ai-agentic/hierarchical-agents.md
@@ -313,40 +313,41 @@ the cap its own parent handed it.
 
 ## 6. ASCII structure diagram
 
-```text
-                         +----------------------+
-                         |   Root Supervisor     |
-                         |  global goal + budget  |
-                         +----------+------------+
-                                    |
-                delegates branch goals, propagates
-                a fraction of the global budget
-                                    |
-          +-------------------------+-------------------------+
-          |                                                   |
-+---------v----------+                             +----------v---------+
-|   Team Lead A       |                             |   Team Lead B       |
-|  (research team)     |                             |  (writing team)      |
-|  local budget = 40%  |                             |  local budget = 40%  |
-+----+-----------+----+                             +----+-----------+----+
-     |           |                                       |           |
-  worker      worker                                  worker      worker
- (search)   (scraper)                              (drafting) (citation-check)
-     |           |                                       |           |
-     +-----+-----+                                       +-----+-----+
-           |                                                    |
-   bounded summary result                             bounded summary result
-   flows upward to Team Lead A                        flows upward to Team Lead B
-           |                                                    |
-           +------------------ synthesize -------------------+
-                                    |
-                        Team Lead A and Team Lead B
-                        each report one summary upward
-                                    |
-                         +----------v------------+
-                         |   Root Supervisor       |
-                         |  synthesizes final answer|
-                         +------------------------+
+```
++----------------------+
+| Root Supervisor      |
+| global goal + budget |
++----------------------+
+     | delegates branch goals, propagates a
+     | fraction of the global budget
+     v
++-----------------------------+
+| Team Lead A (research team) |
+| local budget = 40%          |
++-----------------------------+
+     | workers: search, scraper
+     | bounded summary result flows up
+     v
+(Team Lead A's summary)
+
+Root Supervisor also delegates to a second branch:
+
++----------------------------+
+| Team Lead B (writing team) |
+| local budget = 40%         |
++----------------------------+
+     | workers: drafting, citation-check
+     | bounded summary result flows up
+     v
+(Team Lead B's summary)
+
+Team Lead A and Team Lead B each report one summary
+upward to be synthesized.
+
++--------------------------+
+| Root Supervisor          |
+| synthesizes final answer |
++--------------------------+
 ```
 
 ## 7. Dynamics

--- a/patterns/21-sre-operations/README.md
+++ b/patterns/21-sre-operations/README.md
@@ -2,7 +2,7 @@
 
 Origin. Google SRE, AWS Well-Architected
 
-12 entries, 33,508 words. Every entry carries all 18
+12 entries, 33,507 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Behavioral
@@ -12,7 +12,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Chaos Engineering](chaos-engineering.md) | canonical | 2,457 | A distributed system's resilience is, by default, an assumption. |
 | [Checkpoints](checkpoints.md) | canonical | 5,564 | A long-running computation, a stream-processing job, a database, a multi-step workflow, or a distributed training run, must survive a crash without either losing all of its ... |
 | [Emergency Lever](emergency-lever.md) | canonical | 2,472 | During an active incident, an operator often knows which feature or which category of load is causing the problem, but has no fast, safe way to turn it off. |
-| [Error Budget](error-budget.md) | canonical | 2,575 | Engineering teams building on top of a service and the team operating that service structurally want different things. |
+| [Error Budget](error-budget.md) | canonical | 2,574 | Engineering teams building on top of a service and the team operating that service structurally want different things. |
 | [Game Day](game-day.md) | canonical | 2,510 | A system's resilience, a runbook's correctness, and a team's readiness are all assumptions until they are tested against a real failure. |
 | [Graceful Degradation](graceful-degradation.md) | canonical | 2,434 | When a system is overloaded, or a dependency it relies on fails, the naive response is to fail every request outright. |
 | [Regional Evacuation](regional-evacuation.md) | canonical | 2,523 | A multi-site architecture removes a single point of failure at the architectural level, but it does not by itself give an operator a fast, safe, well tested way to actually act on ... |

--- a/patterns/21-sre-operations/error-budget.md
+++ b/patterns/21-sre-operations/error-budget.md
@@ -50,26 +50,29 @@ Skip it for a service with no SLO yet, since an Error Budget has nothing to be d
 ## 6. ASCII structure diagram
 
 ```
-  SLO target (e.g. 99.9% over 30 days)
-        |
-        v
-  +-------------------------+
-  |   Error Budget = 100% - SLO   |
-  +-------------------------+
-        |
-        v
-  +-------------------------+     real incidents consume     +----------------+
-  |   Budget balance          | <----------------------------  |  Consumption   |
-  |   (updated continuously)  |                                |  events        |
-  +-------------------------+                                +----------------+
-        |
-        v
-  budget healthy?  ----- yes -----> ship at normal or faster pace
-        |
-        no
-        |
-        v
-  Error Budget Policy triggers: freeze releases, shift to reliability work
+SLO target, e.g. 99.9% over 30 days
+     |
+     v
++-------------------------------+
+| Error Budget = 100% minus SLO |
++-------------------------------+
+     |
+     v
++--------------------------------------+
+| Budget balance, updated continuously |
++--------------------------------------+
+     ^ real incidents consume from
+     |
++--------------------+
+| Consumption events |
++--------------------+
+
+budget healthy? yes -> ship at normal or faster pace
+budget healthy? no  -> continue below
+     |
+     v
+Error Budget Policy triggers: freeze releases, shift
+to reliability work
 ```
 
 ## 7. Dynamics


### PR DESCRIPTION
## Summary

- Redraws ten more ASCII diagrams that exceeded 78 characters wide,
  the next tier at 80 to 81 characters, down to 51 to 60 characters.
- medallion-architecture.md, stub.md, token-binding-and-dpop.md,
  profunctor.md, hierarchical-agents.md, error-budget.md,
  observer.md, dead-code.md, large-class.md,
  pipeline-architecture.md.
- No structural, prose, reference, or code content changed. Only the
  diagram fences.
- tools/gen-indexes.py was re-run before this commit, regenerating the
  nine family index tables these entries span.

## Notable redesigns

- medallion-architecture.md's bronze, silver, gold layer chain is now
  a straight vertical pipeline, with the catalog and lineage store
  cross-link (it both feeds Gold and is populated from Silver) stated
  in prose rather than drawn as a diagonal arrow.
- large-class.md's Extract Class before-and-after example keeps all
  four responsibility clusters (pricing, fulfillment, notification,
  audit) and the four delegate classes the Order class ends up using.
- dead-code.md's reachability graph section names every live call path
  from every entry point, and the guard-gated branch section keeps the
  distinction between structurally reachable and practically dead.

## Test plan

- [x] check-structure.py, 884 of 884 entries pass
- [x] check-prose.py, 925 of 925 entries pass
- [x] markdownlint-cli2 0.23.2, 0 issues on the ten changed files
- [x] validate-refs.py --strict, every citation resolves
- [x] check-code.py --strict, 2826 compiled, 0 failed, 0 skipped
- [x] gen-indexes.py re-run, nine family README tables regenerated
      and committed alongside the content changes
- [x] git diff --stat -- docs and dist and the root README.md, all
      empty, no unexpected top level changes
- [x] a stray .ref-cache.json diff from the live citation probe was
      reverted before staging

27 more entries with the same width issue remain, to be worked through
in following batches.
