### PR TITLE
fix(patterns) redraw ten more ASCII diagrams under 78 columns

### DIFF
--- a/patterns/06-enterprise-application-architecture/README.md
+++ b/patterns/06-enterprise-application-architecture/README.md
@@ -2,7 +2,7 @@
 
 Origin. Fowler, PoEAA
 
-56 entries, 371,818 words, 4 more planned, 60 total when the family is complete. Every entry carries all 18
+56 entries, 371,808 words, 4 more planned, 60 total when the family is complete. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Base Pattern
@@ -88,7 +88,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Data Mapper](data-mapper.md) | canonical | 5,828 | An application has a domain model made of objects with behavior, and a relational database made of tables, rows, and columns with no behavior. |
 | [Identity Map](identity-map.md) | canonical | 6,357 | An object-relational mapping layer loads rows from a database and turns them into in-memory objects. |
 | [Lazy Load](lazy-load.md) | canonical | 7,284 | An object graph persisted in a relational database is, by its nature, larger than any single query needs. |
-| [Unit of Work](unit-of-work.md) | canonical | 8,827 | An operation touches several objects that came from, or are destined for, a database. |
+| [Unit of Work](unit-of-work.md) | canonical | 8,817 | An operation touches several objects that came from, or are destined for, a database. |
 
 ## Object-Relational Behavioral Patterns
 

--- a/patterns/06-enterprise-application-architecture/unit-of-work.md
+++ b/patterns/06-enterprise-application-architecture/unit-of-work.md
@@ -247,46 +247,55 @@ discussion cross-reference).
 ## 6. ASCII structure diagram
 
 ```
-     +--------------------------+
-     |    Business Transaction  |
-     |   (client / domain svc)  |
-     +--------------------------+
-                 |
-                 | uses
-                 v
-     +--------------------------+          holds          +-------------------+
-     |       Unit of Work       | -----------------------> |    Identity Map   |
-     |--------------------------|                          |-------------------|
-     | - newObjects: []         |                          | id -> object      |
-     | - dirtyObjects: []       |                          +-------------------+
-     | - removedObjects: []     |
-     | + registerNew(obj)       |
-     | + registerDirty(obj)     |
-     | + registerRemoved(obj)   |
-     | + commit()               |
-     +--------------------------+
-          |          ^
-          | uses      | tracks / holds a reference to
-          v          |
-     +--------------------------+          maps            +-------------------+
-     |       Data Mapper        | <----------------------- |   Domain Object   |
-     |--------------------------|                          |-------------------|
-     | + insert(obj)            |                          | + markDirty()     |
-     | + update(obj)            |    (registered variant   |   (calls back     |
-     | + delete(obj)            |     only, dashed line)   |    into UoW)      |
-     +--------------------------+                          +-------------------+
-          |
-          | issues SQL inside one transaction
-          v
-     +--------------------------+
-     |         Database         |
-     +--------------------------+
++--------------------------------------------+
+| Business Transaction (client / domain svc) |
++--------------------------------------------+
+     | uses
+     v
++------------------------+
+| Unit of Work           |
+| - newObjects: []       |
+| - dirtyObjects: []     |
+| - removedObjects: []   |
+| + registerNew(obj)     |
+| + registerDirty(obj)   |
+| + registerRemoved(obj) |
+| + commit()             |
++------------------------+
+     | holds
+     v
++----------------------------+
+| Identity Map, id -> object |
++----------------------------+
 
-     In the automatic variant, the arrow from Domain Object back to
-     Unit of Work does not exist. Dirtiness is computed by the Unit of
-     Work comparing the live object against a snapshot it took at load
-     time, so Domain Object has no reference to, and no knowledge of,
-     the Unit of Work tracking it.
+Unit of Work also uses:
+
++---------------+
+| Data Mapper   |
+| + insert(obj) |
+| + update(obj) |
+| + delete(obj) |
++---------------+
+     | issues SQL inside one transaction
+     v
++----------+
+| Database |
++----------+
+
+Data Mapper maps a Domain Object:
+
++-----------------------------------+
+| Domain Object                     |
+| + markDirty() calls back into UoW |
++-----------------------------------+
+
+In the registered variant only, a dashed line runs from
+Domain Object back to Unit of Work, tracking a
+reference. In the automatic variant that arrow does not
+exist. Dirtiness is computed by the Unit of Work
+comparing the live object against a snapshot it took at
+load time, so Domain Object has no reference to, and no
+knowledge of, the Unit of Work tracking it.
 ```
 
 ## 7. Dynamics

--- a/patterns/07-integration/README.md
+++ b/patterns/07-integration/README.md
@@ -2,7 +2,7 @@
 
 Origin. Hohpe and Woolf
 
-54 entries, 385,699 words. Every entry carries all 18
+54 entries, 385,674 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Enterprise Integration
@@ -43,7 +43,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 |---|---|---|---|
 | [Canonical Data Model](canonical-data-model.md) | canonical | 7,238 | An enterprise with N independently developed systems that must exchange data pairwise needs, in the worst case, N times (N minus one) point-to-point translators if each system ... |
 | [Channel Purger](channel-purger.md) | canonical | 6,622 | A messaging system accumulates state on its channels in the form of undelivered or unconsumed messages sitting in a queue, a topic partition, or a durable subscription. |
-| [Claim Check](claim-check.md) | canonical | 8,722 | A component in a message-based system needs to communicate a large amount of data, an image, a video, a document, a bulk export, a machine learning feature vector, a full customer ... |
+| [Claim Check](claim-check.md) | canonical | 8,719 | A component in a message-based system needs to communicate a large amount of data, an image, a video, a document, a bulk export, a machine learning feature vector, a full customer ... |
 | [Command Message](command-message.md) | canonical | 6,014 | An application wants another application, or another component in the same system, to perform a specific piece of work. |
 | [Content Enricher](content-enricher.md) | canonical | 6,840 | A message arrives at an integration point carrying less data than the next step needs. |
 | [Content Filter](content-filter.md) | canonical | 8,464 | A consumer receives a message that is far larger, richer, or more deeply nested than anything it needs, and forwarding or storing that full message creates real cost. |
@@ -120,7 +120,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
 | [Channel Adapter](channel-adapter.md) | canonical | 7,811 | An application was written to be called, to poll a database, to read a file, or to raise an in-process event. |
-| [Polling Consumer](polling-consumer.md) | canonical | 5,802 | An application needs to consume messages from a channel, a queue, a topic partition, or any buffered source of work items, but it needs to control the timing and the volume of ... |
+| [Polling Consumer](polling-consumer.md) | canonical | 5,780 | An application needs to consume messages from a channel, a queue, a topic partition, or any buffered source of work items, but it needs to control the timing and the volume of ... |
 
 ## System Management
 

--- a/patterns/07-integration/claim-check.md
+++ b/patterns/07-integration/claim-check.md
@@ -300,34 +300,41 @@ store enforces different access policies for writers and readers.
 
 ## 6. ASCII structure diagram
 
-```text
-                         +-------------------------------+
-                         |          Data Store            |
-                         |  (object storage / blob /       |
-                         |   file share / database)        |
-                         +----------------+-----------------+
-                                  ^                |
-                         (2) put  |                | (5) get
-                         payload  |                | payload
-                                  |                v
-   +----------+        +---------+---------+     +------------------+
-   |  Sender  |  (1)   |     Check-In       |     |    Check-Out     |
-   |          |------->|  (mints the claim  |     | (resolves the    |
-   +----------+ large  |     check)         |     |  claim check)    |
-                payload +---------+---------+     +---------+--------+
-                                  |                          ^
-                         (3) send | thin message              | (4) thin message
-                         (claim   | + claim check              | + claim check
-                          check)  v                          |
-                          +---------------------------+--------+
-                          |      Message Channel                |
-                          |  (queue, topic, event bus)           |
-                          +---------------------------------------+
-                                         |
-                                         v
-                                 +---------------+
-                                 |   Receiver    |
-                                 +---------------+
+```
++--------+
+| Sender |
++--------+
+     | (1) large payload
+     v
++---------------------------------+
+| Check-In, mints the claim check |
++---------------------------------+
+     | (2) put payload
+     v
++-----------------------------------------------------------+
+| Data Store, object storage, blob, file share, or database |
++-----------------------------------------------------------+
+
+Check-In also sends onward, the thin message:
+
+     | (3) thin message + claim check
+     v
++---------------------------------------------+
+| Message Channel, queue, topic, or event bus |
++---------------------------------------------+
+     | routes / filters on metadata only
+     v
++----------+
+| Receiver |
++----------+
+     | (4) if it needs the payload, calls
+     v
++-------------------------------------+
+| Check-Out, resolves the claim check |
++-------------------------------------+
+     | (5) get payload
+     v
+(back to Data Store, payload returns to Receiver)
 ```
 
 ## 7. Dynamics

--- a/patterns/07-integration/polling-consumer.md
+++ b/patterns/07-integration/polling-consumer.md
@@ -196,34 +196,29 @@ Do NOT reach for Polling Consumer when.
 ## 6. ASCII structure diagram
 
 ```
-+-----------------+          poll(timeout, limit)         +------------------+
-|                 | -------------------------------------> |                  |
-|  Polling        |                                        |  Source          |
-|  Consumer       | <------------------------------------- |  (Channel, Queue,|
-|                 |     items[0..limit] or empty            |  Topic, Table)   |
-+--------+--------+                                        +------------------+
-         ^
-         | schedules next call
-         |
-+--------+--------+
-|                 |
-|  Trigger        |
-|  (interval,     |
-|  cron, backoff) |
-|                 |
-+-----------------+
++-----------------------------------+
+| Trigger (interval, cron, backoff) |
++-----------------------------------+
+     | schedules next call
+     v
++------------------+
+| Polling Consumer |
++------------------+
+     | poll(timeout, limit)
+     v
++---------------------------------------+
+| Source (Channel, Queue, Topic, Table) |
++---------------------------------------+
+     | returns items[0..limit], or empty
+     v
+(back to Polling Consumer)
 
-         +------------------------+
-         | Offset / Ack Tracker   |
-         | (last processed index) |
-         +------------------------+
-                    ^
-                    | updated after each
-                    | successfully handled batch
-                    |
-         +----------+----------+
-         |  Polling Consumer   |
-         +---------------------+
+Polling Consumer also updates, after each successfully
+handled batch:
+
++---------------------------------------------+
+| Offset / Ack Tracker (last processed index) |
++---------------------------------------------+
 ```
 
 ## 7. Dynamics

--- a/patterns/10-microservices/README.md
+++ b/patterns/10-microservices/README.md
@@ -2,7 +2,7 @@
 
 Origin. Richardson
 
-49 entries, 364,485 words. Every entry carries all 18
+49 entries, 364,349 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Antipattern
@@ -35,7 +35,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
-| [Microservice Chassis](microservice-chassis.md) | canonical | 8,226 | A single microservice, considered in isolation, is a small and cheap thing to write. |
+| [Microservice Chassis](microservice-chassis.md) | canonical | 8,217 | A single microservice, considered in isolation, is a small and cheap thing to write. |
 
 ## Data
 
@@ -70,7 +70,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
-| [Third Party Registration](third-party-registration.md) | canonical | 8,071 | A caller wants to invoke a service that runs as more than one instance, and those instances are not static. |
+| [Third Party Registration](third-party-registration.md) | canonical | 7,960 | A caller wants to invoke a service that runs as more than one instance, and those instances are not static. |
 
 ## Domain Modeling
 
@@ -115,7 +115,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Distributed Tracing](distributed-tracing.md) | canonical | 7,618 | A single user-facing request in a microservice architecture fans out into a call graph. |
 | [Exception Tracking](exception-tracking.md) | established | 8,433 | A request arrives at a service instance and, partway through handling it, code raises an exception the calling frames do not catch. |
 | [Log Aggregation](log-aggregation.md) | canonical | 8,736 | A service in a microservices system emits log lines to its own local standard output or to a file inside its own container. |
-| [Log Deployments and Changes](log-deployments-changes.md) | established | 9,444 | An engineer is paged. A service that was healthy an hour ago now returns higher error rates, or its latency has doubled, or a queue is backing up. |
+| [Log Deployments and Changes](log-deployments-changes.md) | established | 9,428 | An engineer is paged. A service that was healthy an hour ago now returns higher error rates, or its latency has doubled, or a queue is backing up. |
 
 ## Reliability
 

--- a/patterns/10-microservices/log-deployments-changes.md
+++ b/patterns/10-microservices/log-deployments-changes.md
@@ -93,42 +93,48 @@ The relationship worth naming explicitly is that the Change Origin depends on th
 ## 6. ASCII structure diagram
 
 ```
-+------------------+        +------------------+        +------------------+
-|  Change Origin    |        |   Change Event    |        |   Event Sink      |
-|------------------|  emits |------------------|  writes|------------------|
-| CI/CD pipeline    | -----> | subject           | -----> | metrics annotator |
-| GitOps reconciler |        | version/sha       |        | log aggregator    |
-| kubectl / terraform|       | environment       |        | release tracker   |
-| feature flag flip |        | actor, timestamp  |        | audit log         |
-+------------------+        +------------------+        +--------+---------+
-                                                                   |
-                                                                   | persists
-                                                                   v
-                                                          +------------------+
-                                                          |   Change Ledger   |
-                                                          |------------------|
-                                                          | queryable history |
-                                                          | of every change,  |
-                                                          | per service and   |
-                                                          | environment       |
-                                                          +--------+---------+
-                                                                   |
-                                                                   | queried by
-                                                                   v
-                                                          +------------------+
-                                                          |    Correlator      |
-                                                          |------------------|
-                                                          | overlays events on |
-                                                          | metrics/logs/traces|
-                                                          | surfaces "what     |
-                                                          | changed recently"  |
-                                                          +------------------+
-                                                                   ^
-                                                                   |
-                                                          +------------------+
-                                                          |     Responder      |
-                                                          | (on-call engineer) |
-                                                          +------------------+
++---------------------+
+| Change Origin       |
+| CI/CD pipeline      |
+| GitOps reconciler   |
+| kubectl / terraform |
+| feature flag flip   |
++---------------------+
+     | emits
+     v
++-----------------------------------+
+| Change Event                      |
+| subject, version/sha, environment |
+| actor, timestamp                  |
++-----------------------------------+
+     | writes
+     v
++-------------------+
+| Event Sink        |
+| metrics annotator |
+| log aggregator    |
+| release tracker   |
+| audit log         |
++-------------------+
+     | persists
+     v
++------------------------------------------------+
+| Change Ledger                                  |
+| queryable history of every change, per service |
+| and environment                                |
++------------------------------------------------+
+     | queried by
+     v
++----------------------------------------+
+| Correlator                             |
+| overlays events on metrics/logs/traces |
+| surfaces what changed recently         |
++----------------------------------------+
+     ^
+     |
++------------------------------+
+| Responder (on-call engineer) |
++------------------------------+
 ```
 
 ## 7. Dynamics

--- a/patterns/10-microservices/microservice-chassis.md
+++ b/patterns/10-microservices/microservice-chassis.md
@@ -266,32 +266,47 @@ Do not reach for a Microservice Chassis when any of the following hold.
 ## 6. ASCII structure diagram
 
 ```
-                     +-----------------------------+
-                     |   Chassis (versioned lib)    |
-                     +-------------------------------+
-                     | Config loader                |
-                     | Health check module           |
-                     | Structured logging module     |
-                     | Metrics exporter               |
-                     | Trace propagation              |
-                     | Circuit breaker wrapper         |
-                     | Auth / token validation         |
-                     | Extension points (hooks)         |
-                     +---------------+-----------------+
-                                     ^
-              depends on (compile/build time)
-        +-----------------+---------+---------+-----------------+
-        |                 |                   |                 |
-+---------------+ +---------------+   +---------------+ +---------------+
-| Order Service  | | Payment Svc    |   | Shipping Svc   | | Catalog Svc    |
-+----------------+ +----------------+   +----------------+ +----------------+
-| Domain logic   | | Domain logic    |   | Domain logic    | | Domain logic    |
-| Service config | | Service config  |   | Service config  | | Service config  |
-| Custom hooks   | | Custom hooks    |   | Custom hooks    | | Custom hooks    |
-+---------------+ +---------------+   +---------------+ +---------------+
++---------------------------+
+| Chassis (versioned lib)   |
+| Config loader             |
+| Health check module       |
+| Structured logging module |
+| Metrics exporter          |
+| Trace propagation         |
+| Circuit breaker wrapper   |
+| Auth / token validation   |
+| Extension points (hooks)  |
++---------------------------+
+     ^ depends on (compile/build time)
+     |
++----------------+
+| Order Service  |
+| Domain logic   |
+| Service config |
+| Custom hooks   |
++----------------+
++----------------+
+| Payment Svc    |
+| Domain logic   |
+| Service config |
+| Custom hooks   |
++----------------+
++----------------+
+| Shipping Svc   |
+| Domain logic   |
+| Service config |
+| Custom hooks   |
++----------------+
++----------------+
+| Catalog Svc    |
+| Domain logic   |
+| Service config |
+| Custom hooks   |
++----------------+
 
-     Each service inherits health check, logging, metrics, tracing,
-     circuit breaker, auth. Each service supplies everything else.
+Each service inherits health check, logging, metrics,
+tracing, circuit breaker, auth. Each service supplies
+everything else.
 ```
 
 ## 7. Dynamics

--- a/patterns/10-microservices/third-party-registration.md
+++ b/patterns/10-microservices/third-party-registration.md
@@ -81,46 +81,37 @@ The Service Registry is the datastore of currently available instances and their
 ## 6. Diagram
 
 ```
-+------------------------------------------------------------------+
-|                     Deployment Host / Cluster                    |
-|                                                                    |
-|   +-----------------+   +-----------------+   +-----------------+ |
-|   | Service Instance |   | Service Instance |   | Service Instance| |
-|   |   (unmodified)    |   |   (unmodified)    |   |   (unmodified)   | |
-|   |  no registration   |   |  no registration   |   |  no registration  | |
-|   |     client code     |   |     client code     |   |     client code    | |
-|   +---------+---------+   +---------+---------+   +---------+--------+ |
-|             |  container lifecycle events (start / stop / health)  |
-|             v                       v                       v      |
-|      +---------------------------------------------------------+  |
-|      |         Container / Orchestrator Runtime Events           |  |
-|      |     (Docker Engine events, Marathon events, Mesos API)    |  |
-|      +----------------------------+------------------------------+  |
-|                                    |                                 |
-|                                    v                                 |
-|                       +------------------------+                    |
-|                       |       Registrar         |                   |
-|                       |  (third party component) |                   |
-|                       |  e.g. Registrator, Prana,  |                  |
-|                       |  a custom watcher process  |                  |
-|                       +-----------+--------------+                   |
-|                                   |                                  |
-|                                   | register(instance, address, port) |
-|                                   | deregister(instance)              |
-|                                   v                                  |
-|                       +------------------------+                    |
-|                       |     Service Registry     |                  |
-|                       |   (Consul / etcd / ZK)    |                  |
-|                       +-----------+--------------+                  |
-|                                   ^                                 |
-|                                   | query registered instances       |
-+-----------------------------------|---------------------------------+
-                                     |
-                        +------------+-------------+
-                        |    Discovery Client         |
-                        |  (client side or server     |
-                        |   side discovery consumer)  |
-                        +----------------------------+
+Deployment Host / Cluster
+
++------------------------------------------------------------+
+| Service Instance (unmodified, no registration client code) |
++------------------------------------------------------------+
+(three such instances, each identical)
+     | container lifecycle events (start / stop /
+     | health)
+     v
++--------------------------------------------------+
+| Container / Orchestrator Runtime Events          |
+| Docker Engine events, Marathon events, Mesos API |
++--------------------------------------------------+
+     |
+     v
++---------------------------------------------------+
+| Registrar (third party component)                 |
+| e.g. Registrator, Prana, a custom watcher process |
++---------------------------------------------------+
+     | register(instance, address, port)
+     | deregister(instance)
+     v
++---------------------------------------+
+| Service Registry (Consul / etcd / ZK) |
++---------------------------------------+
+     ^ query registered instances
+     |
++-----------------------------------------------+
+| Discovery Client                              |
+| client side or server side discovery consumer |
++-----------------------------------------------+
 ```
 
 ## 7. Dynamics

--- a/patterns/11-domain-driven-design/README.md
+++ b/patterns/11-domain-driven-design/README.md
@@ -2,7 +2,7 @@
 
 Origin. Evans, Vernon
 
-35 entries, 264,687 words. Every entry carries all 18
+35 entries, 264,653 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Anti-pattern
@@ -56,14 +56,14 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 |---|---|---|---|
 | [Domain Storytelling](domain-storytelling.md) | established | 8,120 | A team building software for a business domain needs an accurate, shared picture of how work actually happens before it can decide what the software should do. |
 | [Generic Subdomain](generic-subdomain.md) | canonical | 6,775 | A team building a real product spends real engineering time on things the business does not actually compete on. |
-| [Ubiquitous Language](ubiquitous-language.md) | canonical | 6,581 | A software team building a system for a business domain sits between two worlds that speak differently about the same reality. |
+| [Ubiquitous Language](ubiquitous-language.md) | canonical | 6,566 | A software team building a system for a business domain sits between two worlds that speak differently about the same reality. |
 
 ## Strategic Design
 
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
 | [Bounded Context](bounded-context.md) | canonical | 6,827 | A software system of any real size accumulates more than one team, more than one department's worldview, and more than one legitimate meaning for the same word. |
-| [Conformist](conformist.md) | canonical | 6,538 | Two bounded contexts need to exchange data or invoke each other's behaviour, and one of the two, the upstream, owns a model neither side is free to renegotiate. |
+| [Conformist](conformist.md) | canonical | 6,519 | Two bounded contexts need to exchange data or invoke each other's behaviour, and one of the two, the upstream, owns a model neither side is free to renegotiate. |
 | [Context Canvas](context-canvas.md) | established | 7,622 | A team has decided, usually from an Event Storming session or from a Context Map already in hand, that a particular slice of the domain deserves its own bounded context. |
 | [Context Map](context-map.md) | canonical | 7,294 | A system reaches a certain size and a certain number of contributing teams before a single, internally consistent domain model stops being achievable. |
 | [Core Domain](core-domain.md) | canonical | 6,670 | A team building a non-trivial system faces a resource allocation problem long before it faces a technical one. |

--- a/patterns/11-domain-driven-design/conformist.md
+++ b/patterns/11-domain-driven-design/conformist.md
@@ -218,34 +218,38 @@ contexts rather than objects.
 
 ## 6. ASCII structure diagram
 
-```text
-                     no negotiating power
-    +----------------------------------------------+
-    |                                                v
-+---+---------------------+                +----------------------+
-|  Upstream Bounded        |                |  Downstream Bounded   |
-|  Context (e.g. Stripe)   |                |  Context (Booking)    |
-|                          |                |                       |
-|  Charge                  |------------->  |  uses Charge directly |
-|  Refund                  |   published    |  uses Refund directly |
-|  PaymentIntent           |   API/SDK      |  no BookingPayment    |
-|  IdempotencyKey          |                |  type exists          |
-+--------------------------+                +-----------------------+
-                                                        |
-                                                        v
-                                             Downstream's own domain
-                                             logic now speaks in the
-                                             upstream's vocabulary,
-                                             wired directly, with no
-                                             translation boundary in
-                                             between the two.
+```
++-----------------------------------------------+
+| Upstream Bounded Context, e.g. Stripe         |
+| Charge, Refund, PaymentIntent, IdempotencyKey |
++-----------------------------------------------+
+     | published API/SDK, no negotiating power
+     v
++--------------------------------------------+
+| Downstream Bounded Context (Booking)       |
+| uses Charge directly, uses Refund directly |
+| no BookingPayment type exists              |
++--------------------------------------------+
 
-  Compare with an Anticorruption Layer relationship.
+Downstream's own domain logic now speaks in the
+upstream's vocabulary, wired directly, with no
+translation boundary in between the two.
 
-+--------------------------+      +-----------+      +-----------------------+
-|  Upstream Bounded         |----->|  ACL      |----->|  Downstream Bounded    |
-|  Context                  |      |(translate)|      |  Context, own model    |
-+--------------------------+      +-----------+      +-----------------------+
+Compare with an Anticorruption Layer relationship.
+
++--------------------------+
+| Upstream Bounded Context |
++--------------------------+
+     |
+     v
++-----------------+
+| ACL (translate) |
++-----------------+
+     |
+     v
++---------------------------------------+
+| Downstream Bounded Context, own model |
++---------------------------------------+
 ```
 
 ## 7. Dynamics

--- a/patterns/11-domain-driven-design/ubiquitous-language.md
+++ b/patterns/11-domain-driven-design/ubiquitous-language.md
@@ -203,44 +203,41 @@ given moment, corrected as understanding sharpens.
 ## 6. ASCII structure diagram
 
 ```
-+-------------------+          converses with          +-------------------+
-|   Domain Expert    | <-------------------------------> |     Developer      |
-|  (owns real-world   |                                   | (owns code that    |
-|   domain knowledge) |                                   |  encodes the model)|
-+-------------------+                                    +-------------------+
-          \                                                        /
-           \   both sides correct terms that feel wrong           /
-            \   ("this word is not what we mean")                /
-             v                                                  v
-                     +---------------------------------+
-                     |      Ubiquitous Language          |
-                     |  (one vocabulary, used in         |
-                     |   speech, code, tests, docs)       |
-                     +---------------------------------+
-                                     |
-                          grounds and is grounded by
-                                     v
-                     +---------------------------------+
-                     |          Domain Model             |
-                     |  (entities, rules, relationships)  |
-                     +---------------------------------+
-                                     |
-                        holds only within
-                                     v
-                     +---------------------------------+
-                     |         Bounded Context           |
-                     |  (the boundary where this exact    |
-                     |   language and model apply)        |
-                     +---------------------------------+
-                                     |
-                    outside this boundary, terms may
-                    legitimately mean something else,
-                    reconciled via Context Mapping
-                                     v
-                     +---------------------------------+
-                     |     Neighboring Bounded Context    |
-                     |    (its own Ubiquitous Language)   |
-                     +---------------------------------+
++-------------------------------------------------+
+| Domain Expert, owns real-world domain knowledge |
++-------------------------------------------------+
++---------------------------------------------+
+| Developer, owns code that encodes the model |
++---------------------------------------------+
+
+Both sides converse with each other, correcting terms
+that feel wrong, this word is not what we mean.
+     |
+     v
++---------------------------------------------------+
+| Ubiquitous Language                               |
+| one vocabulary, used in speech, code, tests, docs |
++---------------------------------------------------+
+     | grounds and is grounded by
+     v
++----------------------------------------------+
+| Domain Model, entities, rules, relationships |
++----------------------------------------------+
+     | holds only within
+     v
++--------------------------------------------------------+
+| Bounded Context                                        |
+| the boundary where this exact language and model apply |
++--------------------------------------------------------+
+     |
+     | outside this boundary, terms may legitimately
+     | mean something else, reconciled via Context
+     | Mapping
+     v
++-----------------------------+
+| Neighboring Bounded Context |
+| its own Ubiquitous Language |
++-----------------------------+
 ```
 
 ## 7. Dynamics

--- a/patterns/12-data-storage/README.md
+++ b/patterns/12-data-storage/README.md
@@ -2,7 +2,7 @@
 
 Origin. Kleppmann
 
-45 entries, 319,776 words. Every entry carries all 18
+45 entries, 319,760 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Concurrency Control
@@ -46,7 +46,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Hinted Handoff](hinted-handoff.md) | canonical | 5,677 | A leaderless, replicated key-value store assigns each key to a fixed set of N nodes, typically the next N nodes clockwise on a consistent-hashing ring. |
 | [Kappa Architecture](kappa-architecture.md) | established | 6,510 | A team running analytics or derived views over an event stream commonly starts with a batch pipeline. |
 | [LSM Tree](lsm-tree.md) | canonical | 9,064 | A key-value or wide-column store needs to sustain a high rate of writes, including writes that touch keys scattered across the entire key space, while still answering point ... |
-| [Lamport Clock](lamport-clock.md) | canonical | 6,460 | A distributed system has no shared memory and no shared clock. |
+| [Lamport Clock](lamport-clock.md) | canonical | 6,444 | A distributed system has no shared memory and no shared clock. |
 | [Leaderless Replication](leaderless-replication.md) | canonical | 7,925 | A single-leader replicated database routes every write through one node. |
 | [Log Compaction](log-compaction.md) | established | 8,019 | An append-only log is the simplest and most dependable storage primitive a distributed system offers. |
 | [Medallion Architecture](medallion-architecture.md) | established | 7,047 | A data platform ingests information from many upstream systems. |

--- a/patterns/12-data-storage/README.md
+++ b/patterns/12-data-storage/README.md
@@ -2,7 +2,7 @@
 
 Origin. Kleppmann
 
-45 entries, 319,823 words. Every entry carries all 18
+45 entries, 319,807 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Concurrency Control
@@ -46,7 +46,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Hinted Handoff](hinted-handoff.md) | canonical | 5,677 | A leaderless, replicated key-value store assigns each key to a fixed set of N nodes, typically the next N nodes clockwise on a consistent-hashing ring. |
 | [Kappa Architecture](kappa-architecture.md) | established | 6,510 | A team running analytics or derived views over an event stream commonly starts with a batch pipeline. |
 | [LSM Tree](lsm-tree.md) | canonical | 9,064 | A key-value or wide-column store needs to sustain a high rate of writes, including writes that touch keys scattered across the entire key space, while still answering point ... |
-| [Lamport Clock](lamport-clock.md) | canonical | 6,460 | A distributed system has no shared memory and no shared clock. |
+| [Lamport Clock](lamport-clock.md) | canonical | 6,444 | A distributed system has no shared memory and no shared clock. |
 | [Leaderless Replication](leaderless-replication.md) | canonical | 7,925 | A single-leader replicated database routes every write through one node. |
 | [Log Compaction](log-compaction.md) | established | 8,019 | An append-only log is the simplest and most dependable storage primitive a distributed system offers. |
 | [Medallion Architecture](medallion-architecture.md) | established | 7,094 | A data platform ingests information from many upstream systems. |

--- a/patterns/12-data-storage/lamport-clock.md
+++ b/patterns/12-data-storage/lamport-clock.md
@@ -201,30 +201,28 @@ compare unequal, which is exactly the limitation dimension 4 names.
 
 ## 6. ASCII structure diagram
 
-```text
-+----------------------+          +----------------------+
-|      Process P        |          |      Process Q        |
-|  local_clock: int      |          |  local_clock: int      |
-+-----------+------------+          +-----------+------------+
-            |                                    |
-            | on internal event:                  | on internal event:
-            |   local_clock += 1                   |   local_clock += 1
-            |                                    |
-            | on send(msg) event:                  |
-            |   local_clock += 1                   |
-            |   msg.timestamp = local_clock         |
-            +---------- msg [ts] --------------->  |
-                                                    |
-                                                    | on receive(msg) event:
-                                                    |   local_clock =
-                                                    |     max(local_clock,
-                                                    |         msg.timestamp) + 1
-                                                    |
-+------------------------------------------------------------------+
-|                 Clock Condition (Lamport, 1978)                    |
-|   a happened-before b   implies   C(a) < C(b)                      |
-|   C(a) < C(b)            does NOT imply   a happened-before b       |
-+------------------------------------------------------------------+
+```
++-----------------------------+
+| Process P, local_clock: int |
++-----------------------------+
+     | on internal event: local_clock += 1
+     | on send(msg) event: local_clock += 1,
+     | msg.timestamp = local_clock
+     v
+msg [ts] sent to Process Q
+
++-----------------------------+
+| Process Q, local_clock: int |
++-----------------------------+
+     | on internal event: local_clock += 1
+     | on receive(msg) event: local_clock =
+     |   max(local_clock, msg.timestamp) + 1
+
++------------------------------------------------+
+| Clock Condition (Lamport, 1978)                |
+| a happened-before b implies C(a) < C(b)        |
+| C(a) < C(b) does NOT imply a happened-before b |
++------------------------------------------------+
 ```
 
 ## 7. Dynamics

--- a/patterns/14-testing/README.md
+++ b/patterns/14-testing/README.md
@@ -2,7 +2,7 @@
 
 Origin. Meszaros, xUnit Test Patterns
 
-30 entries, 217,034 words. Every entry carries all 18
+30 entries, 217,026 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Test Data
@@ -33,7 +33,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 |---|---|---|---|
 | [Approval Test](approval-test.md) | established | 7,682 | Consider a function that renders an invoice as HTML, a compiler pass that lowers an abstract syntax tree to bytecode, a report generator that produces a multi-page PDF summary, or ... |
 | [Arrange-Act-Assert](arrange-act-assert.md) | canonical | 6,255 | A test that has no imposed shape tends to accrete in whatever order the writer thought of things. |
-| [Characterization Test](characterization-test.md) | canonical | 6,420 | A team inherits a module, a service, or a whole codebase with no tests, or with tests too sparse to trust. |
+| [Characterization Test](characterization-test.md) | canonical | 6,412 | A team inherits a module, a service, or a whole codebase with no tests, or with tests too sparse to trust. |
 | [Contract Test](contract-test.md) | canonical | 8,368 | A team splits a monolith into services, or simply has two teams shipping two deployables that talk over HTTP, gRPC, or a message queue. |
 | [Differential Testing](differential-testing.md) | established | 7,373 | A team owns, or depends on, more than one thing that is meant to compute the same answer. |
 | [Fault Injection](fault-injection.md) | established | 7,609 | Software that talks to another process over a network, a disk, a database connection, or any other boundary will eventually see that boundary fail. |

--- a/patterns/14-testing/README.md
+++ b/patterns/14-testing/README.md
@@ -2,7 +2,7 @@
 
 Origin. Meszaros, xUnit Test Patterns
 
-30 entries, 217,028 words. Every entry carries all 18
+30 entries, 217,020 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Test Data
@@ -33,7 +33,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 |---|---|---|---|
 | [Approval Test](approval-test.md) | established | 7,682 | Consider a function that renders an invoice as HTML, a compiler pass that lowers an abstract syntax tree to bytecode, a report generator that produces a multi-page PDF summary, or ... |
 | [Arrange-Act-Assert](arrange-act-assert.md) | canonical | 6,255 | A test that has no imposed shape tends to accrete in whatever order the writer thought of things. |
-| [Characterization Test](characterization-test.md) | canonical | 6,420 | A team inherits a module, a service, or a whole codebase with no tests, or with tests too sparse to trust. |
+| [Characterization Test](characterization-test.md) | canonical | 6,412 | A team inherits a module, a service, or a whole codebase with no tests, or with tests too sparse to trust. |
 | [Contract Test](contract-test.md) | canonical | 8,368 | A team splits a monolith into services, or simply has two teams shipping two deployables that talk over HTTP, gRPC, or a message queue. |
 | [Differential Testing](differential-testing.md) | established | 7,373 | A team owns, or depends on, more than one thing that is meant to compute the same answer. |
 | [Fault Injection](fault-injection.md) | established | 7,609 | Software that talks to another process over a network, a disk, a database connection, or any other boundary will eventually see that boundary fail. |

--- a/patterns/14-testing/characterization-test.md
+++ b/patterns/14-testing/characterization-test.md
@@ -207,21 +207,30 @@ unprotected.
 ## 6. ASCII structure diagram
 
 ```
-+-----------------------+        drives         +---------------------------+
-|      Test Driver       | ---------------------> | System Under              |
-|  (owns chosen inputs)  |                        | Characterization          |
-+-----------------------+ <--------------------- |  (existing legacy code)   |
-            |               observed output       +---------------------------+
-            |
-            v
-+-----------------------+     compares against   +---------------------------+
-|      Comparator        | ---------------------> |     Captured Reference    |
-|  (equality or diff)     |                        |  (inline literal, or a    |
-|                         |                        |   stored golden file)     |
-+-----------------------+                        +---------------------------+
-            |
-            v
-      pass / fail signal
++----------------------------------+
+| Test Driver (owns chosen inputs) |
++----------------------------------+
+     | drives
+     v
++------------------------------------------------------+
+| System Under Characterization (existing legacy code) |
++------------------------------------------------------+
+     | observed output
+     v
+(back to Test Driver)
+
++-------------------------------+
+| Comparator (equality or diff) |
++-------------------------------+
+     | compares against
+     v
++-----------------------------------------+
+| Captured Reference                      |
+| inline literal, or a stored golden file |
++-----------------------------------------+
+     |
+     v
+pass / fail signal
 ```
 
 ## 7. Dynamics


### PR DESCRIPTION
## Summary

- Redraws ten more ASCII diagrams that exceeded 78 characters wide,
  the next tier at 80 characters, down to 50 to 62 characters.
- unit-of-work.md, claim-check.md, polling-consumer.md,
  log-deployments-changes.md, microservice-chassis.md,
  third-party-registration.md, conformist.md,
  ubiquitous-language.md, lamport-clock.md,
  characterization-test.md.
- No structural, prose, reference, or code content changed. Only the
  diagram fences.
- tools/gen-indexes.py was re-run before this commit, regenerating the
  six family index tables these entries span.

## Notable redesigns

- claim-check.md's structure diagram and its own dynamics section
  (section 7) disagreed on where Check-Out sits in the flow. The
  dynamics section is authoritative, the Receiver calls Check-Out to
  resolve the claim check, rather than Check-Out being a parallel
  sibling to Check-In fed directly by the Message Channel. The
  redrawn diagram now matches the dynamics section.
- unit-of-work.md keeps the distinction between the registered
  variant (a dashed back-reference from Domain Object to Unit of
  Work) and the automatic variant (no such reference, dirtiness
  computed from a load-time snapshot).
- microservice-chassis.md keeps all four consuming services (Order,
  Payment, Shipping, Catalog) and every chassis module they inherit.

## Test plan

- [x] check-structure.py, 884 of 884 entries pass
- [x] check-prose.py, 925 of 925 entries pass
- [x] markdownlint-cli2 0.23.2, 0 issues on the ten changed files
- [x] validate-refs.py --strict, every citation resolves
- [x] check-code.py --strict, 2826 compiled, 0 failed, 0 skipped
- [x] gen-indexes.py re-run, six family README tables regenerated and
      committed alongside the content changes
- [x] git diff --stat -- docs and dist and the root README.md, all
      empty, no unexpected top level changes

17 more entries with the same width issue remain, to be worked through
in following batches.
