### PR TITLE
fix(patterns) redraw ten more ASCII diagrams under 78 columns

### DIFF
--- a/patterns/03-refactoring/encapsulate-collection.md
+++ b/patterns/03-refactoring/encapsulate-collection.md
@@ -153,26 +153,40 @@ class enforces its invariants in those methods.
 ## 6. ASCII structure diagram
 
 ```
-  BEFORE                                  AFTER
-  ------                                  -----
+BEFORE
+------
 
-  class Course:                          class Course:
-    attendees: List<Student>               _attendees: List<Student>  (private)
-                                           MAX = 30
-    getAttendees(): List<Student>
-      return attendees                    getAttendees(): List<Student>
-                                             return unmodifiable(_attendees)
-  caller:
-    course.getAttendees().add(s)          enroll(student):
-      // bypasses capacity check             if len(_attendees) >= MAX:
-                                                 raise FullError
-                                             _attendees.add(student)
+class Course:
+  attendees: List<Student>
 
-                                         cancel(student):
-                                             _attendees.remove(student)
+  getAttendees(): List<Student>
+    return attendees
 
-                                         caller:
-                                             course.enroll(s)  // checked
+caller:
+  course.getAttendees().add(s)
+    // bypasses capacity check
+
+
+AFTER
+-----
+
+class Course:
+  _attendees: List<Student>  (private)
+  MAX = 30
+
+  getAttendees(): List<Student>
+    return unmodifiable(_attendees)
+
+  enroll(student):
+    if len(_attendees) >= MAX:
+      raise FullError
+    _attendees.add(student)
+
+  cancel(student):
+    _attendees.remove(student)
+
+caller:
+  course.enroll(s)  // checked
 ```
 
 ## 7. Dynamics

--- a/patterns/04-principles-and-laws/README.md
+++ b/patterns/04-principles-and-laws/README.md
@@ -2,7 +2,7 @@
 
 Origin. Martin, Larman, Brewer, Conway
 
-42 entries, 327,228 words. Every entry carries all 18
+42 entries, 327,232 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Design Principle
@@ -35,7 +35,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Controller](controller.md) | canonical | 6,874 | A team wiring a new interaction into an object-oriented system reaches a concrete, recurring question the moment a user clicks a button, submits a form, or an external system ... |
 | [Conway's Law](conway-law.md) | canonical | 7,751 | A team is asked to build a system with several distinct concerns. |
 | [Creator](creator.md) | canonical | 7,514 | Every object-oriented system eventually needs a new object of type A to come into existence somewhere, and the code that calls the constructor has to live in some class B. |
-| [Do Not Repeat Yourself](do-not-repeat-yourself.md) | canonical | 6,449 | A single fact about the system, a tax rate, a validation rule, a URL, a unit conversion, a business rule about who is allowed to approve a refund, gets written down in more than ... |
+| [Do Not Repeat Yourself](do-not-repeat-yourself.md) | canonical | 6,453 | A single fact about the system, a tax rate, a validation rule, a URL, a unit conversion, a business rule about who is allowed to approve a refund, gets written down in more than ... |
 | [Fail Fast](fail-fast.md) | established | 7,090 | A running program encounters a state it was not written to handle correctly. |
 | [High Cohesion](high-cohesion.md) | canonical | 8,014 | A team splits a system into modules, classes, packages, or services, and almost every split is defensible on some axis. |
 | [Idiomatic](idiomatic.md) | canonical | 7,073 | A person who learns to program in one language carries that language's mental model into every language learned afterward. |

--- a/patterns/04-principles-and-laws/do-not-repeat-yourself.md
+++ b/patterns/04-principles-and-laws/do-not-repeat-yourself.md
@@ -205,22 +205,40 @@ mechanism carries it out.
 ## 6. ASCII structure diagram
 
 ```
-  Before                              After
+Before
 
-  +----------------+                  +----------------+
-  | Checkout code  |                  | Checkout code  |
-  | tax = p * r    |                  | orderTotal(p,r)|--+
-  +----------------+                  +----------------+  |
-                                                            v
-  +----------------+                  +----------------+  +-----------------+
-  | Receipt code   |                  | Receipt code   |  | orderTotal(p,r) |
-  | tax = p * r    |                  | orderTotal(p,r)|->| single, owned,  |
-  +----------------+                  +----------------+  | authoritative   |
-                                                            +-----------------+
-  Two independent copies of the       One representation, two consumers
-  formula. A tax-law change means     bound to it. A tax-law change means
-  finding and editing both, and       editing one function. Both callers
-  nothing enforces they still match.  agree by construction, not by care.
++---------------+
+| Checkout code |
+| tax = p * r   |
++---------------+
++--------------+
+| Receipt code |
+| tax = p * r  |
++--------------+
+
+Two independent copies of the formula. A tax-law
+change means finding and editing both, and nothing
+enforces they still match.
+
+After
+
++------------------+
+| Checkout code    |
+| orderTotal(p, r) |
++------------------+
++------------------+
+| Receipt code     |
+| orderTotal(p, r) |
++------------------+
+     | both call
+     v
++------------------------------------------------+
+| orderTotal(p, r), single, owned, authoritative |
++------------------------------------------------+
+
+One representation, two consumers bound to it. A
+tax-law change means editing one function. Both
+callers agree by construction, not by care.
 ```
 
 ## 7. Dynamics

--- a/patterns/05-architectural/README.md
+++ b/patterns/05-architectural/README.md
@@ -2,7 +2,7 @@
 
 Origin. Buschmann POSA 1, Bass SEI
 
-31 entries, 248,937 words. Every entry carries all 18
+31 entries, 248,910 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Architectural
@@ -36,7 +36,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Plugin Sandbox](plugin-sandbox.md) | established | 10,826 | A host application defines an extension point, using Plugin Architecture or Microkernel, so that its behavior can grow without every new feature being merged into the core ... |
 | [Primary-Replica](primary-replica.md) | canonical | 7,665 | A single database instance handling both writes and reads eventually hits a ceiling on at least one of three axes, read throughput, availability, and geographic latency. |
 | [Serverless Architecture](serverless-architecture.md) | established | 8,872 | A team owns a backend that must handle a workload with two properties that are hard to satisfy at once with a conventional server fleet, the load is spiky or unpredictable, and ... |
-| [Service-Oriented Architecture](service-oriented-architecture.md) | contested | 6,727 | A monolithic application starts as the fastest way to ship. |
+| [Service-Oriented Architecture](service-oriented-architecture.md) | contested | 6,700 | A monolithic application starts as the fastest way to ship. |
 | [Shared Nothing](shared-nothing.md) | canonical | 7,785 | A system needs to handle more work than one machine can handle, whether that work is transaction throughput, storage volume, or concurrent connections. |
 | [Space-Based Architecture](space-based-architecture.md) | established | 7,002 | A system built as a stateless application tier in front of a single relational database scales the application tier easily and the database tier badly. |
 | [VIPER](viper.md) | established | 8,403 | A screen in a UIKit or AppKit application tends to accumulate three kinds of code inside one view controller, code that lays out and updates the user interface, code that decides ... |

--- a/patterns/05-architectural/service-oriented-architecture.md
+++ b/patterns/05-architectural/service-oriented-architecture.md
@@ -262,32 +262,39 @@ the rule.
 ## 6. ASCII structure diagram
 
 ```
-                         +----------------------+
-                         |   Service Registry    |
-                         |  (contracts, versions, |
-                         |   network locations)   |
-                         +-----------+------------+
-                                     ^
-                        register /   |   discover
-                        publish  |   |
-                                 v   v
-+----------------+      +--------------------+      +------------------+
-| Service         |----->|   API Gateway /    |<-----| Service          |
-| Consumer         |      |   Enterprise       |      | Consumer          |
-| (client app,     |      |   Service Bus       |      | (another service) |
-|  batch job)       |<-----|   (routing, auth,   |----->|                  |
-+----------------+      |   policy, optional) |      +------------------+
-                         +----------+---------+
-                                    |
-                +-------------------+-------------------+
-                |                   |                    |
-                v                   v                    v
-     +--------------------+ +--------------------+ +--------------------+
-     | Service Provider A  | | Service Provider B  | | Service Provider C  |
-     | (e.g. Orders)        | | (e.g. Inventory)     | | (e.g. Payments)      |
-     |  Contract. OrderAPI  | |  Contract. StockAPI  | |  Contract. PayAPI    |
-     |  Owns. orders DB     | |  Owns. stock DB      | |  Owns. ledger DB     |
-     +--------------------+ +--------------------+ +--------------------+
++----------------------------------------+
+| Service Registry                       |
+| contracts, versions, network locations |
++----------------------------------------+
+     ^ register / publish, discover
+     |
++--------------------------------------+
+| API Gateway / Enterprise Service Bus |
+| routing, auth, policy, optional      |
++--------------------------------------+
+     ^ used by
+     |
++-------------------------------------------+
+| Service Consumer, client app or batch job |
++-------------------------------------------+
++-----------------------------------+
+| Service Consumer, another service |
++-----------------------------------+
+
+API Gateway / ESB routes to three providers:
+
++-----------------------------------+
+| Service Provider A, e.g. Orders   |
+| Contract OrderAPI, owns orders DB |
++-----------------------------------+
++------------------------------------+
+| Service Provider B, e.g. Inventory |
+| Contract StockAPI, owns stock DB   |
++------------------------------------+
++-----------------------------------+
+| Service Provider C, e.g. Payments |
+| Contract PayAPI, owns ledger DB   |
++-----------------------------------+
 ```
 
 ## 7. Dynamics

--- a/patterns/06-enterprise-application-architecture/README.md
+++ b/patterns/06-enterprise-application-architecture/README.md
@@ -2,7 +2,7 @@
 
 Origin. Fowler, PoEAA
 
-56 entries, 371,808 words, 4 more planned, 60 total when the family is complete. Every entry carries all 18
+56 entries, 371,715 words, 4 more planned, 60 total when the family is complete. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Base Pattern
@@ -122,13 +122,13 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
 | [Embedded Value](embedded-value.md) | canonical | 7,871 | An application's domain model routinely needs small objects that group a handful of related fields into one meaningful unit. |
-| [Identity Field](identity-field.md) | canonical | 6,033 | An in-memory object system and a relational database use two different, and incompatible, notions of identity. |
+| [Identity Field](identity-field.md) | canonical | 6,034 | An in-memory object system and a relational database use two different, and incompatible, notions of identity. |
 
 ## Object-Relational Structural Patterns
 
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
-| [Concrete Table Inheritance](concrete-table-inheritance.md) | canonical | 8,078 | An application's domain model contains a base type with several concrete subtypes, each subtype adding its own fields, and the persistence layer must map that hierarchy onto ... |
+| [Concrete Table Inheritance](concrete-table-inheritance.md) | canonical | 7,984 | An application's domain model contains a base type with several concrete subtypes, each subtype adding its own fields, and the persistence layer must map that hierarchy onto ... |
 | [Inheritance Mappers](inheritance-mappers.md) | canonical | 8,397 | A domain model with an inheritance hierarchy, a base Employee class with SalariedEmployee, CommissionedEmployee, and HourlyEmployee subclasses, needs a persistence layer that can ... |
 | [Single Table Inheritance](single-table-inheritance.md) | canonical | 9,071 | An object model has a natural inheritance hierarchy. |
 

--- a/patterns/06-enterprise-application-architecture/README.md
+++ b/patterns/06-enterprise-application-architecture/README.md
@@ -2,7 +2,7 @@
 
 Origin. Fowler, PoEAA
 
-56 entries, 371,818 words, 4 more planned, 60 total when the family is complete. Every entry carries all 18
+56 entries, 371,725 words, 4 more planned, 60 total when the family is complete. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Base Pattern
@@ -122,13 +122,13 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
 | [Embedded Value](embedded-value.md) | canonical | 7,871 | An application's domain model routinely needs small objects that group a handful of related fields into one meaningful unit. |
-| [Identity Field](identity-field.md) | canonical | 6,033 | An in-memory object system and a relational database use two different, and incompatible, notions of identity. |
+| [Identity Field](identity-field.md) | canonical | 6,034 | An in-memory object system and a relational database use two different, and incompatible, notions of identity. |
 
 ## Object-Relational Structural Patterns
 
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
-| [Concrete Table Inheritance](concrete-table-inheritance.md) | canonical | 8,078 | An application's domain model contains a base type with several concrete subtypes, each subtype adding its own fields, and the persistence layer must map that hierarchy onto ... |
+| [Concrete Table Inheritance](concrete-table-inheritance.md) | canonical | 7,984 | An application's domain model contains a base type with several concrete subtypes, each subtype adding its own fields, and the persistence layer must map that hierarchy onto ... |
 | [Inheritance Mappers](inheritance-mappers.md) | canonical | 8,397 | A domain model with an inheritance hierarchy, a base Employee class with SalariedEmployee, CommissionedEmployee, and HourlyEmployee subclasses, needs a persistence layer that can ... |
 | [Single Table Inheritance](single-table-inheritance.md) | canonical | 9,071 | An object model has a natural inheritance hierarchy. |
 

--- a/patterns/06-enterprise-application-architecture/concrete-table-inheritance.md
+++ b/patterns/06-enterprise-application-architecture/concrete-table-inheritance.md
@@ -280,52 +280,57 @@ matters more than the rule.
 ## 6. ASCII structure diagram
 
 ```
-                     +---------------------------+
-                     |     PaymentMethod          |
-                     |     in-memory only,        |
-                     |     no table                |
-                     |-----------------------------|
-                     | + amount                    |
-                     | + currency                  |
-                     | + createdAt                 |
-                     +---------------------------+
-                        ^          ^          ^
-                        |          |          |
-        +---------------+   +------+-----+  +-+----------------+
-        | CreditCardPayment|  | BankTransfer|  | PayPalPayment    |
-        |------------------|  | Payment     |  |------------------|
-        | + maskedPan      |  |-------------|  | + payerEmail     |
-        | + expiryMonth    |  | + iban      |  | + payerId        |
-        +---------+--------+  | + bic       |  +---------+--------+
-                  |            +------+------+            |
-                  |                    |                    |
-                  v                    v                    v
-        +-------------------+ +-------------------+ +-------------------+
-        | credit_card_       | | bank_transfer_    | | paypal_           |
-        | payments TABLE     | | payments TABLE     | | payments TABLE    |
-        |--------------------| |---------------------| |--------------------|
-        | id, PK, seq         | | id, PK, seq          | | id, PK, seq        |
-        | amount              | | amount               | | amount             |
-        | currency            | | currency             | | currency           |
-        | created_at          | | created_at           | | created_at         |
-        | masked_pan          | | iban                 | | payer_email        |
-        | expiry_month        | | bic                  | | payer_id           |
-        +--------------------+ +----------------------+ +--------------------+
++-----------------------------------------+
+| PaymentMethod, in-memory only, no table |
+| + amount                                |
+| + currency                              |
+| + createdAt                             |
++-----------------------------------------+
+     ^ extended by three subclasses
+     |
++-------------------+
+| CreditCardPayment |
+| + maskedPan       |
+| + expiryMonth     |
++-------------------+
+     |
+     v
++------------------------------------------+
+| credit_card_payments TABLE               |
+| id PK seq, amount, currency, created_at, |
+| masked_pan, expiry_month                 |
++------------------------------------------+
 
-     No table exists for PaymentMethod. No foreign key connects the three
-     concrete tables to one another. The shared columns amount, currency,
-     and created_at are physically duplicated in every table.
++---------------------+
+| BankTransferPayment |
+| + iban              |
+| + bic               |
++---------------------+
+     |
+     v
++------------------------------------------------+
+| bank_transfer_payments TABLE                   |
+| id PK seq, amount, currency, created_at, iban, |
+| bic                                            |
++------------------------------------------------+
 
-     A rare polymorphic read is served by a UNION ALL, roughly like this.
++---------------+
+| PayPalPayment |
+| + payerEmail  |
+| + payerId     |
++---------------+
+     |
+     v
++------------------------------------------+
+| paypal_payments TABLE                    |
+| id PK seq, amount, currency, created_at, |
+| payer_email, payer_id                    |
++------------------------------------------+
 
-        SELECT id, amount, currency, created_at, 'card' AS kind
-          FROM credit_card_payments
-        UNION ALL
-        SELECT id, amount, currency, created_at, 'transfer' AS kind
-          FROM bank_transfer_payments
-        UNION ALL
-        SELECT id, amount, currency, created_at, 'paypal' AS kind
-          FROM paypal_payments
+No table exists for PaymentMethod. No foreign key
+connects the three concrete tables to one another. The
+shared columns amount, currency, and created_at are
+physically duplicated in every table.
 ```
 
 ## 7. Dynamics

--- a/patterns/06-enterprise-application-architecture/identity-field.md
+++ b/patterns/06-enterprise-application-architecture/identity-field.md
@@ -218,22 +218,36 @@ rather than client-assigned.
 ## 6. ASCII structure diagram
 
 ```
-+-----------------------+          maps to           +----------------------+
-|     Domain Object     |  <----------------------->  |    Database Table    |
-|  (e.g. Customer)      |                             |   (e.g. customers)   |
-+-----------------------+                             +----------------------+
-| - id: Long            |  <== Identity Field ==>     | id     BIGINT   PK   |
-| - name: String        |                             | name   VARCHAR       |
-| - email: String       |                             | email  VARCHAR       |
-+-----------------------+                             +----------------------+
-        ^                                                       ^
-        |  assigned by                                          |  enforced by
-        |                                                       |
-+-----------------------+                             +----------------------+
-|    Key Generator       |  --- produces next value -> |  PRIMARY KEY and     |
-|  (sequence, UUID gen,  |                             |  UNIQUE constraint   |
-|   IDENTITY column)     |                             +----------------------+
-+-----------------------+
++--------------------------------------+
+| Domain Object, e.g. Customer         |
+| - id: Long        <== Identity Field |
+| - name: String                       |
+| - email: String                      |
++--------------------------------------+
+     | maps to
+     v
++----------------------------------------+
+| Database Table, e.g. customers         |
+| id     BIGINT   PK  <== Identity Field |
+| name   VARCHAR                         |
+| email  VARCHAR                         |
++----------------------------------------+
+
+Domain Object's id is assigned by:
+
++----------------------------------------+
+| Key Generator                          |
+| sequence, UUID gen, or IDENTITY column |
++----------------------------------------+
+     | produces next value
+     v
+(assigned to Domain Object's id)
+
+Database Table's id is enforced by:
+
++-----------------------------------+
+| PRIMARY KEY and UNIQUE constraint |
++-----------------------------------+
 ```
 
 ## 7. Dynamics

--- a/patterns/07-integration/README.md
+++ b/patterns/07-integration/README.md
@@ -2,7 +2,7 @@
 
 Origin. Hohpe and Woolf
 
-54 entries, 385,674 words. Every entry carries all 18
+54 entries, 385,663 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Enterprise Integration
@@ -49,13 +49,13 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Content Filter](content-filter.md) | canonical | 8,464 | A consumer receives a message that is far larger, richer, or more deeply nested than anything it needs, and forwarding or storing that full message creates real cost. |
 | [Correlation Identifier](correlation-identifier.md) | canonical | 7,422 | A process sends a message and does not receive its answer over the same connection it used to send it. |
 | [Document Message](document-message.md) | canonical | 7,017 | Two systems need to exchange a structured record, such as a customer record, a purchase order, a lab result, or a shipment manifest. |
-| [Dynamic Router](dynamic-router.md) | canonical | 7,649 | A message-routing component in a system needs to send a message onward, and the set of places it might send that message to is not fixed at the time the router is built, deployed ... |
+| [Dynamic Router](dynamic-router.md) | canonical | 7,665 | A message-routing component in a system needs to send a message onward, and the set of places it might send that message to is not fixed at the time the router is built, deployed ... |
 | [Event Message](event-message.md) | canonical | 7,035 | An application performs an action that other applications, possibly ones the first application has never heard of and will never know about, need to react to. |
 | [Event-Driven Consumer](event-driven-consumer.md) | canonical | 6,039 | A service needs to react when something happens elsewhere in the system, a payment is captured, an order is placed, a file lands in a bucket, a row is updated in another team's ... |
 | [Format Indicator](format-indicator.md) | canonical | 6,130 | A message travels from a producer to a consumer, and at some point the consumer must decide how to parse the bytes it received. |
 | [Message](message.md) | canonical | 6,901 | Two applications need to exchange information without either one blocking on the other's availability, without either one dictating the other's internal data model, and without a ... |
 | [Message Bus](message-bus.md) | canonical | 7,670 | A system starts with two applications that need to exchange data, and a direct point-to-point integration, a script that reads from one database and writes to another, or a ... |
-| [Message Channel](message-channel.md) | canonical | 6,008 | Two independently deployed pieces of software need to exchange information, and the team building them does not want a synchronous, point-to-point network call between them. |
+| [Message Channel](message-channel.md) | canonical | 5,981 | Two independently deployed pieces of software need to exchange information, and the team building them does not want a synchronous, point-to-point network call between them. |
 | [Message Dispatcher](message-dispatcher.md) | canonical | 7,081 | A single logical stream of work needs to be processed by more capacity than one consumer thread can provide, and the team wants that capacity applied without breaking three ... |
 | [Message Expiration](message-expiration.md) | canonical | 6,898 | A message carries a request or a piece of data across an asynchronous boundary. |
 | [Message Filter](message-filter.md) | canonical | 7,478 | A component sits on a message channel and receives every message that flows past, but it only knows how to handle a subset of them. |

--- a/patterns/07-integration/README.md
+++ b/patterns/07-integration/README.md
@@ -2,7 +2,7 @@
 
 Origin. Hohpe and Woolf
 
-54 entries, 385,699 words. Every entry carries all 18
+54 entries, 385,688 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Enterprise Integration
@@ -49,13 +49,13 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Content Filter](content-filter.md) | canonical | 8,464 | A consumer receives a message that is far larger, richer, or more deeply nested than anything it needs, and forwarding or storing that full message creates real cost. |
 | [Correlation Identifier](correlation-identifier.md) | canonical | 7,422 | A process sends a message and does not receive its answer over the same connection it used to send it. |
 | [Document Message](document-message.md) | canonical | 7,017 | Two systems need to exchange a structured record, such as a customer record, a purchase order, a lab result, or a shipment manifest. |
-| [Dynamic Router](dynamic-router.md) | canonical | 7,649 | A message-routing component in a system needs to send a message onward, and the set of places it might send that message to is not fixed at the time the router is built, deployed ... |
+| [Dynamic Router](dynamic-router.md) | canonical | 7,665 | A message-routing component in a system needs to send a message onward, and the set of places it might send that message to is not fixed at the time the router is built, deployed ... |
 | [Event Message](event-message.md) | canonical | 7,035 | An application performs an action that other applications, possibly ones the first application has never heard of and will never know about, need to react to. |
 | [Event-Driven Consumer](event-driven-consumer.md) | canonical | 6,039 | A service needs to react when something happens elsewhere in the system, a payment is captured, an order is placed, a file lands in a bucket, a row is updated in another team's ... |
 | [Format Indicator](format-indicator.md) | canonical | 6,130 | A message travels from a producer to a consumer, and at some point the consumer must decide how to parse the bytes it received. |
 | [Message](message.md) | canonical | 6,901 | Two applications need to exchange information without either one blocking on the other's availability, without either one dictating the other's internal data model, and without a ... |
 | [Message Bus](message-bus.md) | canonical | 7,670 | A system starts with two applications that need to exchange data, and a direct point-to-point integration, a script that reads from one database and writes to another, or a ... |
-| [Message Channel](message-channel.md) | canonical | 6,008 | Two independently deployed pieces of software need to exchange information, and the team building them does not want a synchronous, point-to-point network call between them. |
+| [Message Channel](message-channel.md) | canonical | 5,981 | Two independently deployed pieces of software need to exchange information, and the team building them does not want a synchronous, point-to-point network call between them. |
 | [Message Dispatcher](message-dispatcher.md) | canonical | 7,081 | A single logical stream of work needs to be processed by more capacity than one consumer thread can provide, and the team wants that capacity applied without breaking three ... |
 | [Message Expiration](message-expiration.md) | canonical | 6,898 | A message carries a request or a piece of data across an asynchronous boundary. |
 | [Message Filter](message-filter.md) | canonical | 7,478 | A component sits on a message channel and receives every message that flows past, but it only knows how to handle a subset of them. |

--- a/patterns/07-integration/dynamic-router.md
+++ b/patterns/07-integration/dynamic-router.md
@@ -240,52 +240,56 @@ Iteratively evaluated shape.
 ```
 Self-registering shape
 
-  +--------------+  register(conditions)   +-----------------+
-  | Destination A|------------------------>|                  |
-  +--------------+                         |                  |
-                                            |     Router       |
-  +--------------+  register(conditions)   |  (rule base held |
-  | Destination B|------------------------>|   in memory)     |
-  +--------------+                         |                  |
-                                            +---------+--------+
-                    message                          |
-  Producer -------------------------------------------> match against rule base
-                                            +---------+--------+
-                                                       |
-                                        route to A, B, or neither
-                                                       v
-                                    +--------------+       +--------------+
-                                    | Destination A|       | Destination B|
-                                    +--------------+       +--------------+
++---------------+
+| Destination A |
++---------------+
++---------------+
+| Destination B |
++---------------+
+     | register(conditions), each
+     v
++----------------------------------+
+| Router, rule base held in memory |
++----------------------------------+
+     ^ message
+     |
++----------+
+| Producer |
++----------+
+
+Router matches the message against the rule base and
+routes it to A, to B, to both, or to neither.
 
 
 Iteratively evaluated shape
 
-  Producer --> message --> +------------------+
-                            |     Router       |
-                            +------------------+
-                                     |
-                                     |  call routingFunction(msg, history)
-                                     v
-                            +------------------+
-                            | Routing Function |----> returns Destination 1
-                            +------------------+
-                                     |
-                             forward to Destination 1, append to history
-                                     |
-                                     v
-                            +------------------+
-                            |     Router       |  (message returns for hop 2)
-                            +------------------+
-                                     |
-                                     |  call routingFunction(msg, history)
-                                     v
-                            +------------------+
-                            | Routing Function |----> returns null
-                            +------------------+
-                                     |
-                                     v
-                              routing complete
++----------+
+| Producer |
++----------+
+     | message
+     v
++--------+
+| Router |
++--------+
+     | call routingFunction(msg, history)
+     v
++-----------------------------------------+
+| Routing Function, returns Destination 1 |
++-----------------------------------------+
+     | forward, append Destination 1 to history
+     v
++---------------+
+| Destination 1 |
++---------------+
+     | message returns to the Router for hop 2
+     v
++--------------------------------------------------+
+| Router calls routingFunction(msg, history) again |
++--------------------------------------------------+
+
+Each hop, the Router asks the Routing Function again,
+now with the growing history, until the function
+returns no further destination.
 ```
 
 ## 7. Dynamics

--- a/patterns/07-integration/message-channel.md
+++ b/patterns/07-integration/message-channel.md
@@ -229,37 +229,46 @@ group tracks its own independent read offset.
 ## 6. ASCII structure diagram
 
 ```
-                       MESSAGE CHANNEL (point-to-point shape)
+Point-to-point shape
 
-  +------------+       write        +--------------------+       read
-  |  Sender    | -----------------> |   Message Channel   | <----------------+
-  | (Producer) |                    |  (named, addressed, |                  |
-  +------------+                    |   FIFO or log-based |     +------------+
-                                     |   persistent store) |     | Receiver A |
-                                     +----------+----------+     | (Consumer) |
-                                                |                +------------+
-                                                |  one consumer reads
-                                                |  each message once
-                                                v
-                                     +------------+
-                                     | Receiver B |
-                                     | (Consumer) |
-                                     +------------+
++------------------+
+| Sender, Producer |
++------------------+
+     | write
+     v
++-------------------------------------------+
+| Message Channel                           |
+| named, addressed, FIFO or log-based store |
++-------------------------------------------+
+     | read, one consumer reads each message once
+     v
++----------------------+
+| Receiver A, Consumer |
++----------------------+
++----------------------+
+| Receiver B, Consumer |
++----------------------+
 
 
-                     MESSAGE CHANNEL (publish-subscribe shape)
+Publish-subscribe shape
 
-  +------------+       write        +--------------------+
-  |  Sender    | -----------------> |   Message Channel   |
-  | (Producer) |                    |   (topic / exchange |
-  +------------+                    |    with N sub feeds)|
-                                     +----+-----------+----+
-                                          |           |
-                          each consumer   |           |   each consumer
-                          gets its OWN    v           v   gets its OWN
-                          full copy   +--------+  +--------+
-                                      | Sub A  |  | Sub B  |
-                                      +--------+  +--------+
++------------------+
+| Sender, Producer |
++------------------+
+     | write
+     v
++------------------------------------+
+| Message Channel                    |
+| topic or exchange with N sub feeds |
++------------------------------------+
+     | fans out, each consumer gets its own full copy
+     v
++-------+
+| Sub A |
++-------+
++-------+
+| Sub B |
++-------+
 ```
 
 ## 7. Dynamics

--- a/patterns/08-cloud-distributed/README.md
+++ b/patterns/08-cloud-distributed/README.md
@@ -2,7 +2,7 @@
 
 Origin. Azure Architecture Center, Nygard
 
-44 entries, 393,044 words. Every entry carries all 18
+44 entries, 393,059 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Capacity Management
@@ -63,7 +63,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
-| [Command Query Responsibility Segregation](cqrs.md) | established | 11,603 | A single model is being asked to serve two jobs whose requirements have diverged, and the model is losing on both. |
+| [Command Query Responsibility Segregation](cqrs.md) | established | 11,618 | A single model is being asked to serve two jobs whose requirements have diverged, and the model is losing on both. |
 
 ## Data and Persistence
 

--- a/patterns/08-cloud-distributed/cqrs.md
+++ b/patterns/08-cloud-distributed/cqrs.md
@@ -338,38 +338,55 @@ often, and dimension 11 records what it looks like when it breaks.
 ## 6. ASCII structure diagram
 
 ```
-                        +---------------------------+
-   intent               |         Client            |            need
-   (mutate)             +---------------------------+          (display)
-       |                   |                     |                  |
-       v                   v                     v                  v
-+--------------+  Command  |                     |  Query   +---------------+
-|   Command    |<----------+                     +--------->|     Query     |
-|   Handler    |                                            |    Handler    |
-+--------------+                                            +---------------+
-       |                                                            |
-       | load / save                                                | read only
-       v                                                            v
-+--------------+                                            +---------------+
-|  Write Model |                                            |   Read Model  |
-|  (aggregate) |                                            |  (projection) |
-|              |                                            |               |
-| invariants   |                                            | denormalised  |
-| normalised   |                                            | per-screen    |
-| small graph  |                                            | version/offset|
-+--------------+                                            +---------------+
-       |                                                            ^
-       v                                                            |
-+--------------+       +------------------+       +-----------------+
-| Write Store  |------>|   Synchroniser   |------>|   Projection    |
-| (SoR)        | change|  outbox / CDC /  | event | apply(event) ->  |
-+--------------+ feed  |  event stream    |       | mutate view      |
-                       +------------------+       +-----------------+
++--------+
+| Client |
++--------+
+     ^ intent, mutate       ^ need, display
+     |                      |
++--------------------+
+| Command Handler    |
++--------------------+
++--------------------+
+| Query Handler      |
++--------------------+
+(Client sends a Command to mutate, or issues a
+Query to read; the two paths never cross)
 
-   Legend
-   SoR          system of record, the only authority on current state
-   Synchroniser present only in the separate-store variant
-   ------>      data flow, never a call back in the reverse direction
++-------------------------------------+
+| Write Model, aggregate              |
+| invariants, normalised, small graph |
++-------------------------------------+
+     | load / save
+     v
++-----------------------------------------+
+| Write Store, the system of record (SoR) |
++-----------------------------------------+
+     | change feed
+     v
++--------------------------------------------+
+| Synchroniser, outbox, CDC, or event stream |
+| present only in the separate-store variant |
++--------------------------------------------+
+     | event, apply(event) mutates the view
+     v
++------------+
+| Projection |
++------------+
+     | writes
+     v
++-----------------------------------------------+
+| Read Model, projection                        |
+| denormalised, per-screen, versioned or offset |
++-----------------------------------------------+
+     ^ read only
+     |
+(Query Handler reads the Read Model directly, never
+the Write Model)
+
+The one-store variant is the same picture with the
+Write Store through Projection row deleted, and both
+models pointing at the same database. Data flows one
+way only, never a call back in the reverse direction.
 ```
 
 The one-store variant is the same picture with the bottom row deleted and both

--- a/patterns/15-security/README.md
+++ b/patterns/15-security/README.md
@@ -2,7 +2,7 @@
 
 Origin. OWASP ASVS
 
-38 entries, 226,886 words. Every entry carries all 18
+38 entries, 226,885 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Authorization
@@ -34,7 +34,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Idempotency Key](idempotency-key.md) | established | 6,606 | A client sends a mutating request and then loses the answer. |
 | [Input Validation](input-validation.md) | canonical | 6,182 | A program accepts bytes, strings, numbers, objects, headers, files, paths, identifiers, query parameters, form fields, JSON bodies, environment variables, messages, or records ... |
 | [JWT](jwt.md) | established | 6,076 | A resource server needs to accept repeated calls without contacting the issuer for every request, yet it still needs an issuer, subject, audience, expiry, possibly scopes, and a ... |
-| [Key Rotation](key-rotation.md) | established | 6,762 | A system depends on secret material that cannot be treated as permanent. |
+| [Key Rotation](key-rotation.md) | established | 6,761 | A system depends on secret material that cannot be treated as permanent. |
 | [Least Privilege](least-privilege.md) | canonical | 6,389 | A system needs trusted actions to happen, but the code, user, service account, container, or job that performs those actions can also fail, be tricked, or be taken over. |
 | [Lethal Trifecta Threat Model](lethal-trifecta-threat-model.md) | emerging | 1,818 | Willison's own text states why the three conditions matter only in combination, not individually. |
 | [Mutual TLS](mutual-tls.md) | established | 6,027 | A service accepts network calls from other machines. |

--- a/patterns/15-security/key-rotation.md
+++ b/patterns/15-security/key-rotation.md
@@ -257,27 +257,42 @@ make old ciphertext unrecoverable.
 ## 6. ASCII structure diagram
 
 ```
-+-------------------+        +-----------------------+
-| Rotation          | create | Logical Key Name      |
-| Coordinator       |------->| payments-signing      |
-+---------+---------+        +-----------+-----------+
-          |                              |
-          | publishes state              | owns versions
-          v                              v
-+---------+---------+        +-----------+-----------+
-| Distribution Path |<-------| Version Registry      |
-| store, JWKS, KMS  |        | v1, v2, v3 states     |
-+---------+---------+        +-----------+-----------+
-          |                              |
-          | fetch current and accepted   | records events
-          v                              v
-+---------+---------+        +-----------+-----------+
-| Consumers         |------->| Audit Sink            |
-| writers, readers  | use    | logs and metrics      |
-+-------------------+        +-----------------------+
++----------------------+
+| Rotation Coordinator |
++----------------------+
+     | create
+     v
++-----------------------------------------+
+| Logical Key Name, e.g. payments-signing |
++-----------------------------------------+
+     | owns versions
+     v
++-------------------------------------+
+| Version Registry, v1, v2, v3 states |
++-------------------------------------+
+     | records events
+     v
++------------------------------+
+| Audit Sink, logs and metrics |
++------------------------------+
 
-Writers use one active version. Readers accept a bounded version set.
-Old versions leave the set only after their protected work can no longer appear.
+Rotation Coordinator also publishes state to:
+
++-------------------------------------+
+| Distribution Path, store, JWKS, KMS |
++-------------------------------------+
+     | fetch current and accepted
+     v
++-----------------------------+
+| Consumers, writers, readers |
++-----------------------------+
+     | use
+     v
+(reports to Audit Sink above)
+
+Writers use one active version. Readers accept a
+bounded version set. Old versions leave the set only
+after their protected work can no longer appear.
 ```
 
 ## 7. Dynamics

--- a/patterns/21-sre-operations/README.md
+++ b/patterns/21-sre-operations/README.md
@@ -2,7 +2,7 @@
 
 Origin. Google SRE, AWS Well-Architected
 
-12 entries, 33,507 words. Every entry carries all 18
+12 entries, 33,510 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Behavioral
@@ -11,7 +11,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 |---|---|---|---|
 | [Chaos Engineering](chaos-engineering.md) | canonical | 2,457 | A distributed system's resilience is, by default, an assumption. |
 | [Checkpoints](checkpoints.md) | canonical | 5,564 | A long-running computation, a stream-processing job, a database, a multi-step workflow, or a distributed training run, must survive a crash without either losing all of its ... |
-| [Emergency Lever](emergency-lever.md) | canonical | 2,472 | During an active incident, an operator often knows which feature or which category of load is causing the problem, but has no fast, safe way to turn it off. |
+| [Emergency Lever](emergency-lever.md) | canonical | 2,475 | During an active incident, an operator often knows which feature or which category of load is causing the problem, but has no fast, safe way to turn it off. |
 | [Error Budget](error-budget.md) | canonical | 2,574 | Engineering teams building on top of a service and the team operating that service structurally want different things. |
 | [Game Day](game-day.md) | canonical | 2,510 | A system's resilience, a runbook's correctness, and a team's readiness are all assumptions until they are tested against a real failure. |
 | [Graceful Degradation](graceful-degradation.md) | canonical | 2,434 | When a system is overloaded, or a dependency it relies on fails, the naive response is to fail every request outright. |

--- a/patterns/21-sre-operations/emergency-lever.md
+++ b/patterns/21-sre-operations/emergency-lever.md
@@ -50,26 +50,26 @@ Skip it for a feature so essential that disabling it would itself constitute the
 ## 6. ASCII structure diagram
 
 ```
-  Lever definition
-  (scope + Effect boundary,
-   built and tested in advance)
-        |
-        v
-  incident detected, an authorized operator decides to pull it
-        |
-        v
-  Trigger mechanism executed
-        |
-        v
-  Action log records who, what, and why
-        |
-        v
-  incident contained?  ----- yes -----> lever stays pulled until safe to release
-        |
-        no
-        |
-        v
-  operator escalates to a different mitigation
+Lever definition
+scope + Effect boundary, built and tested in advance
+     |
+     v
+Incident detected, an authorized operator decides to
+pull it
+     |
+     v
+Trigger mechanism executed
+     |
+     v
+Action log records who, what, and why
+     |
+     v
+incident contained? yes -> lever stays pulled until
+                           safe to release
+incident contained? no  -> continue below
+     |
+     v
+Operator escalates to a different mitigation
 ```
 
 ## 7. Dynamics


### PR DESCRIPTION
Batch 13 of the ASCII-diagram width remediation pass.

Ten entries redrawn so every diagram line stays under 78 columns,
across families 03, 04, 05, 06, 07, 08, 15, and 21.

- key-rotation
- emergency-lever
- encapsulate-collection
- do-not-repeat-yourself
- service-oriented-architecture
- concrete-table-inheritance
- identity-field
- dynamic-router
- message-channel
- cqrs

Multi-branch layouts (a fan-out registry, a before/after code pair,
a two-column consumer fan, a parallel read/write split) are redrawn
as vertical chains with the branch relationship named in prose,
the same simplification used in batches 7 through 12.

Gates run clean. check-structure.py (884/884), check-family-names.py,
check-prose.py (925/925), markdownlint-cli2 0.23.2 (0 issues),
validate-refs.py --strict (every citation resolves), check-code.py
--strict (2826 compiled, 0 failed). gen-indexes.py regenerated all
affected family README.md tables.