### PR TITLE
fix(patterns) redraw the final seven ASCII diagrams under 78 columns

### DIFF
--- a/patterns/08-cloud-distributed/README.md
+++ b/patterns/08-cloud-distributed/README.md
@@ -2,7 +2,7 @@
 
 Origin. Azure Architecture Center, Nygard
 
-44 entries, 393,044 words. Every entry carries all 18
+44 entries, 393,045 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Capacity Management
@@ -137,7 +137,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Competing Consumers](competing-consumers.md) | canonical | 7,217 | A system produces units of work faster, or in bursts larger, than a single consumer process can absorb, and the units of work are independent of one another, meaning any one of ... |
 | [Priority Queue](priority-queue.md) | canonical | 10,299 | A distributed system that processes work through a queue, whether that queue is a message broker topic, a job table, a task list, or a pending pod list, eventually accumulates ... |
 | [Queue-Based Load Leveling](queue-based-load-leveling.md) | canonical | 9,730 | A system accepts work at a rate that varies over time, sometimes sharply, while the component that actually performs the work has a roughly fixed processing capacity per unit time. |
-| [Rate Limiting](rate-limiting.md) | canonical | 10,988 | A service exposes an operation that costs something to perform. |
+| [Rate Limiting](rate-limiting.md) | canonical | 10,989 | A service exposes an operation that costs something to perform. |
 | [Throttling](throttling.md) | canonical | 10,477 | A service exposes an operation that costs something to run. |
 
 ## Security

--- a/patterns/08-cloud-distributed/README.md
+++ b/patterns/08-cloud-distributed/README.md
@@ -2,7 +2,7 @@
 
 Origin. Azure Architecture Center, Nygard
 
-44 entries, 393,059 words. Every entry carries all 18
+44 entries, 393,060 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Capacity Management
@@ -137,7 +137,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Competing Consumers](competing-consumers.md) | canonical | 7,217 | A system produces units of work faster, or in bursts larger, than a single consumer process can absorb, and the units of work are independent of one another, meaning any one of ... |
 | [Priority Queue](priority-queue.md) | canonical | 10,299 | A distributed system that processes work through a queue, whether that queue is a message broker topic, a job table, a task list, or a pending pod list, eventually accumulates ... |
 | [Queue-Based Load Leveling](queue-based-load-leveling.md) | canonical | 9,730 | A system accepts work at a rate that varies over time, sometimes sharply, while the component that actually performs the work has a roughly fixed processing capacity per unit time. |
-| [Rate Limiting](rate-limiting.md) | canonical | 10,988 | A service exposes an operation that costs something to perform. |
+| [Rate Limiting](rate-limiting.md) | canonical | 10,989 | A service exposes an operation that costs something to perform. |
 | [Throttling](throttling.md) | canonical | 10,477 | A service exposes an operation that costs something to run. |
 
 ## Security

--- a/patterns/08-cloud-distributed/rate-limiting.md
+++ b/patterns/08-cloud-distributed/rate-limiting.md
@@ -249,47 +249,48 @@ from a wall into a protocol.
 ## 6. ASCII structure diagram
 
 ```
-                        ,-------------------------.
-   inbound request ---> |    Enforcement Point    |
-                        |  (gateway / middleware) |
-                        `------------+------------'
-                                     |
-             (1) key                 v
-        ,--------------------------------------------------.
-        |            Identity Extractor                    |
-        |  api key > account > session > net addr (/64)    |
-        `----------------------+---------------------------'
-                               | key
-                               v
-        ,--------------------------------------------------.
-        |            Policy Resolver                       |
-        |  route + plan -> {limit, window, burst, cost}    |
-        `----------------------+---------------------------'
-                               | key + policy
-                               v
-        ,--------------------------------------------------.
-        |            Decision Engine                       |     atomic
-        |  token bucket | leaky | fixed | log | sliding    |<--> read
-        `----------------------+---------------------------'     modify
-                               | verdict                          write
-                               |  {conform, remaining, reset,       |
-                               |   retry_after, policy_id}          v
-                               |                        ,---------------------.
-        ,----------------------+--------------.         |     Quota Store     |
-        |                                     |         | in-proc map | Redis |
-        v                                     v         |  | DynamoDB | mesh  |
-  ,-----------.                       ,---------------. `---------------------'
-  |  handler  |                       |   Response    |
-  | (admitted)|                       |   Annotator   |
-  `-----------'                       | 429 + headers |
-                                      `-------+-------'
-                                              |
-                                              v
-                                    ,---------------------.
-                                    |   Client Governor   |
-                                    | wait, jitter, self  |
-                                    | throttle, retry     |
-                                    `---------------------'
++------------------------------------------+
+| Enforcement Point, gateway or middleware |
++------------------------------------------+
+     ^ inbound request
+     |
+     v
++-----------------------------------------------------+
+| Identity Extractor                                  |
+| api key over account over session over /64 net addr |
++-----------------------------------------------------+
+     | key
+     v
++--------------------------------------------+
+| Policy Resolver                            |
+| route + plan -> limit, window, burst, cost |
++--------------------------------------------+
+     | key + policy
+     v
++-----------------------------------------------+
+| Decision Engine                               |
+| token bucket, leaky, fixed, log, or sliding   |
+| reads and modifies the Quota Store atomically |
++-----------------------------------------------+
+     | verdict, conform or deny, plus remaining,
+     | reset, retry_after, and policy_id
+     v
+conform? yes -> handler (admitted)
+conform? no  -> Response Annotator
+
++-------------------------------------------+
+| Response Annotator, sets 429 plus headers |
++-------------------------------------------+
+     |
+     v
++---------------------------------------------+
+| Client Governor                             |
+| waits, adds jitter, self-throttles, retries |
++---------------------------------------------+
+
+The Decision Engine's atomic read, modify, write cycle
+runs against the Quota Store, an in-process map, Redis,
+DynamoDB, or a mesh sidecar, held out of this chain.
 ```
 
 ## 7. Dynamics

--- a/patterns/09-concurrency/README.md
+++ b/patterns/09-concurrency/README.md
@@ -2,7 +2,7 @@
 
 Origin. Schmidt POSA 2
 
-40 entries, 318,562 words. Every entry carries all 18
+40 entries, 318,550 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Concurrency
@@ -41,7 +41,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Read-Write Lock](read-write-lock.md) | canonical | 7,855 | A single piece of shared, mutable state is accessed by multiple threads. |
 | [Scheduler](scheduler.md) | canonical | 6,621 | A system has more units of work that want to run than it has execution resources to run them on, or those units of work become eligible at different and unpredictable times, and ... |
 | [Scoped Locking](scoped-locking.md) | canonical | 8,785 | A piece of code acquires a lock to protect a critical section, and every path out of that critical section, the normal return, the early return, the thrown exception, the break ... |
-| [Semaphore](semaphore.md) | canonical | 8,341 | A fixed, known number of interchangeable resources exist. |
+| [Semaphore](semaphore.md) | canonical | 8,329 | A fixed, known number of interchangeable resources exist. |
 | [Strategized Locking](strategized-locking.md) | canonical | 9,027 | A reusable component, a cache, a connection pool, a queue, a counter, a buffer manager, is built once and deployed into more than one concurrency environment. |
 | [Structured Concurrency](structured-concurrency.md) | established | 7,965 | A function spawns concurrent work, a network call, a background computation, a fan-out to several services, and returns before that work is guaranteed to be done. |
 | [Thread Pool](thread-pool.md) | canonical | 7,592 | A server, or any long-running process, receives a stream of independent units of work. |

--- a/patterns/09-concurrency/semaphore.md
+++ b/patterns/09-concurrency/semaphore.md
@@ -225,39 +225,34 @@ failure modes in dimension 11.
 ## 6. ASCII structure diagram
 
 ```
-                         +--------------------------+
-                         |        Semaphore          |
-                         |----------------------------|
-                         | counter: int (permits left)|
-                         | waitSet: queue of Waiter   |
-                         |----------------------------|
-                         | + acquire()                |
-                         | + tryAcquire(): bool        |
-                         | + acquire(timeout): bool    |
-                         | + release()                 |
-                         +--------------------------+
-                              ^                |
-                    acquire() |                | wakes on release()
-                    blocks if |                v
-                    counter=0 |         +----------------+
-                              |         |    Waiter A    |
-                              |         | (blocked task) |
-                              |         +----------------+
-                              |
-                              |         +----------------+
-                              +-------->|    Waiter B    |
-                                        | (blocked task) |
-                                        +----------------+
++------------------------------------------------------+
+| Semaphore                                            |
+| counter: int, permits left                           |
+| waitSet: queue of Waiter                             |
+| acquire(), tryAcquire(), acquire(timeout), release() |
++------------------------------------------------------+
+     ^ blocks and enqueues here when counter is 0
+     |
++------------------------+
+| Waiter A, blocked task |
++------------------------+
++------------------------+
+| Waiter B, blocked task |
++------------------------+
 
-     Holder 1 -- acquire() --> [permit 1 taken] --> uses resource --> release()
-     Holder 2 -- acquire() --> [permit 2 taken] --> uses resource --> release()
-     Holder 3 -- acquire() --> counter is 0, BLOCKS ---------------> woken here
-                                                                       when a
-                                                                       permit
-                                                                       frees up
+Each blocked Waiter is woken in turn when a holder
+calls release() and a permit frees up.
 
-     A semaphore initialised with N permits admits up to N concurrent
-     holders. Holder N+1 blocks in the wait set until any holder releases.
+A semaphore initialised with N permits admits up to N
+concurrent holders. Holder N+1 blocks in the wait set
+until any holder releases.
+
+Holder 1. acquire() -> permit 1 taken -> uses resource
+          -> release()
+Holder 2. acquire() -> permit 2 taken -> uses resource
+          -> release()
+Holder 3. acquire() -> counter is 0, BLOCKS -> woken
+          only when a permit frees up
 ```
 
 ## 7. Dynamics

--- a/patterns/10-microservices/README.md
+++ b/patterns/10-microservices/README.md
@@ -2,7 +2,7 @@
 
 Origin. Richardson
 
-49 entries, 364,349 words. Every entry carries all 18
+49 entries, 364,269 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Antipattern
@@ -60,7 +60,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | Pattern | Maturity | Words | Intent |
 |---|---|---|---|
 | [Multiple Service Instances per Host](multiple-service-instances-per-host.md) | established | 7,536 | A single instance of a service process can only accept as many concurrent connections and use as many CPU cycles as one operating system process gets scheduled. |
-| [Serverless Deployment](serverless-deployment.md) | established | 7,884 | A team owns a piece of business logic that is genuinely small and genuinely bursty. |
+| [Serverless Deployment](serverless-deployment.md) | established | 7,804 | A team owns a piece of business logic that is genuinely small and genuinely bursty. |
 | [Service Deployment Platform](service-deployment-platform.md) | canonical | 7,181 | A team has decomposed an application into a set of independently deployable services, following one of the decomposition patterns in this family, and has chosen how a single ... |
 | [Service Instance per Container](service-instance-per-container.md) | canonical | 8,934 | A team is moving an application, or building a new one, on top of microservices, and has to decide the packaging and scheduling unit for each service instance. |
 | [Service Instance per Host](service-instance-per-host.md) | established | 7,761 | You have already decomposed a system into services, and each service runs as one or more service instances for throughput and redundancy, the same starting context Richardson ... |

--- a/patterns/10-microservices/serverless-deployment.md
+++ b/patterns/10-microservices/serverless-deployment.md
@@ -240,43 +240,30 @@ Do NOT reach for it in these cases, and the reason matters more than the rule.
 ## 6. ASCII structure diagram
 
 ```
-                         +----------------------------+
-                         |        Trigger source      |
-                         |  HTTP route / queue / blob  |
-                         |  notification / schedule    |
-                         +--------------+---------------+
-                                        |
-                                        v
-                         +----------------------------+
-                         |        Orchestrator         |
-                         |  decides. reuse a warm env,  |
-                         |  or cold-start a new one     |
-                         +--------------+---------------+
-                                        |
-                     +------------------+------------------+
-                     |                                      |
-                     v                                      v
-         +----------------------+              +----------------------+
-         |  Execution env #1     |              |  Execution env #2     |
-         |  (warm, reused)       |              |  (cold-started now)   |
-         |                        |              |                        |
-         |  +------------------+  |              |  +------------------+  |
-         |  |  Runtime          |  |              |  |  Runtime          |  |
-         |  |  +-------------+  |  |              |  |  +-------------+  |  |
-         |  |  |  Function    |  |  |              |  |  |  Function    |  |  |
-         |  |  |  handler     |  |  |              |  |  |  handler     |  |  |
-         |  |  +-------------+  |  |              |  |  +-------------+  |  |
-         |  +------------------+  |              |  +------------------+  |
-         +-----------+-----------+              +-----------+-----------+
-                     |                                      |
-                     +------------------+-------------------+
-                                        |
-                                        v
-                         +----------------------------+
-                         |     External state store     |
-                         |  database / object store /    |
-                         |  cache / message bus           |
-                         +----------------------------+
++---------------------------------------------------------------+
+| Trigger source, an HTTP route, queue, blob event, or schedule |
++---------------------------------------------------------------+
+     |
+     v
++--------------------------------------------------+
+| Orchestrator, decides: reuse a warm env, or cold-start|
++--------------------------------------------------+
+     | routes to one of two possible envs
+     v
++--------------------------------+
+| Execution env #1, warm, reused |
+| Runtime -> Function handler    |
++--------------------------------+
++------------------------------------+
+| Execution env #2, cold-started now |
+| Runtime -> Function handler        |
++------------------------------------+
+     | either env
+     v
++-------------------------------------------------+
+| External state store                            |
+| a database, object store, cache, or message bus |
++-------------------------------------------------+
 ```
 
 ## 7. Dynamics

--- a/patterns/13-frontend-ui/README.md
+++ b/patterns/13-frontend-ui/README.md
@@ -2,7 +2,7 @@
 
 Origin. Framework documentation
 
-34 entries, 123,829 words. Every entry carries all 18
+34 entries, 123,828 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Application Architecture
@@ -101,7 +101,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Flux](flux.md) | deprecated | 3,629 | Traditional MVC-style architectures let a view update a model directly, and let multiple models observe and update one another, which becomes difficult to reason about as an ... |
 | [Reducer Hook](reducer-hook.md) | canonical | 3,580 | A component whose state updates are spread across many individual event handlers, each directly calling its own state setter, becomes hard to reason about as the number of related ... |
 | [Redux](redux.md) | canonical | 3,663 | Flux's original architecture solved unidirectional data flow with several independent stores, each holding its own slice of state and its own update logic, which worked but left ... |
-| [Signals](signals.md) | established | 3,294 | A component-based UI framework built on a virtual DOM diff and re-render cycle, such as React, re-runs an entire component function whenever any piece of its state changes, then ... |
+| [Signals](signals.md) | established | 3,293 | A component-based UI framework built on a virtual DOM diff and re-render cycle, such as React, re-runs an entire component function whenever any piece of its state changes, then ... |
 | [State Machine UI](state-machine-ui.md) | established | 3,616 | A component with several loading, error, and success conditions is commonly modeled with several independent boolean flags, such as isLoading, isError, and hasData, tracked as ... |
 
 ## Reading order

--- a/patterns/13-frontend-ui/signals.md
+++ b/patterns/13-frontend-ui/signals.md
@@ -114,19 +114,20 @@ Signals have two structural parts.
 ## 6. ASCII structure diagram
 
 ```
-    count = signal(0)              (the signal itself)
+count = signal(0)              (the signal itself)
 
-              |
-              v  read inside a reactive context
+          |
+          v  read inside a reactive context
 
-    <span>{count}</span>            (a subscriber, a rendered UI fragment)
-    doubled = computed(() => count.value * 2)   (a subscriber, a derived value)
+<span>{count}</span>          (a subscriber, a UI fragment)
+doubled = computed(() => count.value * 2)
+                               (a subscriber, a derived value)
 
-              |
-              v  count.value = 1
+          |
+          v  count.value = 1
 
-    Only the subscribers that actually read count re-evaluate.
-    A sibling component that never reads count does not re-render.
+Only the subscribers that actually read count re-evaluate.
+A sibling component that never reads count does not re-render.
 ```
 
 ## 7. Dynamics

--- a/patterns/16-functional/README.md
+++ b/patterns/16-functional/README.md
@@ -2,7 +2,7 @@
 
 Origin. Category theory in practice
 
-39 entries, 240,724 words. Every entry carries all 18
+39 entries, 240,720 words. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Composition
@@ -47,7 +47,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Function Composition](function-composition.md) | canonical | 7,310 | A program has several small transformations that must run in a fixed order. |
 | [Functor](functor.md) | canonical | 6,739 | A codebase has many values that are not plain values. |
 | [Lazy Evaluation](lazy-evaluation.md) | canonical | 6,415 | A program has a chain of computations, but early execution would do work that may never be observed. |
-| [Lens](lens.md) | established | 6,096 | A program owns nested immutable data and needs to update a small part without losing the larger value. |
+| [Lens](lens.md) | established | 6,092 | A program owns nested immutable data and needs to update a small part without losing the larger value. |
 | [Memoization](memoization.md) | canonical | 6,478 | A program repeatedly asks the same pure question, and each answer costs more than a map lookup. |
 | [Monad](monad.md) | canonical | 6,350 | A program has computations that return values inside a policy, and later computations depend on the successful, present, parsed, or completed result of earlier computations. |
 | [Monoid](monoid.md) | canonical | 6,362 | A codebase has many places that reduce many values into one value. |

--- a/patterns/16-functional/lens.md
+++ b/patterns/16-functional/lens.md
@@ -234,35 +234,35 @@ for library authors than for most application code.
 
 ## 6. ASCII structure diagram
 
-```text
-  +-------------------+       contains        +------------------+
-  |       Whole S     |---------------------->|      Focus A     |
-  |-------------------|                       +------------------+
-  | other fields      |                                ^
-  | focus field       |                                |
-  +-------------------+                                |
-           ^                                           |
-           | rebuilds                                  | reads
-           |                                           |
-  +-------------------+       packages        +------------------+
-  |      Updater      |<----------------------|      Getter      |
-  |-------------------|                       |------------------|
-  | set A in S -> S   |                       | get S -> A       |
-  | over A -> A       |                       +------------------+
-  +-------------------+                                ^
-           ^                                           |
-           |                                           |
-           +-------------------+-----------------------+
-                               |
-                       +---------------+
-                       |   Lens S A    |
-                       |---------------|
-                       | view          |
-                       | set           |
-                       | over          |
-                       +---------------+
+```
++--------------+
+| Whole S      |
+| other fields |
+| focus field  |
++--------------+
+     | contains
+     v
++---------+
+| Focus A |
++---------+
 
-  The lens is the reusable focus. It does not own the whole or the focus value.
++--------------------+
+| Getter, get S -> A |
++--------------------+
+     | reads Focus A out of Whole S
+
++---------------------------------------+
+| Updater, set A in S -> S, over A -> A |
++---------------------------------------+
+     | packages the Getter's read, then rebuilds Whole S
+
++---------------------------+
+| Lens S A, view, set, over |
++---------------------------+
+     | bundles the Getter and the Updater as one pair
+
+The lens is the reusable focus. It does not own the
+whole or the focus value.
 ```
 
 ## 7. Dynamics

--- a/patterns/17-ai-agentic/README.md
+++ b/patterns/17-ai-agentic/README.md
@@ -2,7 +2,7 @@
 
 Origin. Papers and vendor engineering, 2023 to 2026
 
-64 entries, 492,513 words, 1 more planned, 65 total when the family is complete. Every entry carries all 18
+64 entries, 492,490 words, 1 more planned, 65 total when the family is complete. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## AI Agentic
@@ -27,7 +27,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Input Guardrails](input-guardrails.md) | established | 8,596 | An agent built on a large language model treats every token in its context window with roughly the same weight, whether that token came from the person operating the agent, from a ... |
 | [LLM as Judge](llm-as-judge.md) | established | 7,737 | A team ships a feature whose output is open-ended text, a chat reply, a document summary, a retrieval-augmented answer, or an autonomous agent's final report. |
 | [Language Agent Tree Search](language-agent-tree-search.md) | established | 1,913 | The paper's own text names the specific limitation of the prior baseline directly, ReAct. |
-| [Late Chunking](late-chunking.md) | emerging | 8,222 | Picture a retrieval pipeline built over a long, single-narrative source, a Wikipedia article, a signed contract, a meeting transcript, a product manual. |
+| [Late Chunking](late-chunking.md) | emerging | 8,199 | Picture a retrieval pipeline built over a long, single-narrative source, a Wikipedia article, a signed contract, a meeting transcript, a product manual. |
 | [Memory Compaction](memory-compaction.md) | established | 8,946 | An agent that runs for a long time accumulates a conversation. |
 | [PII Redaction](pii-redaction.md) | established | 8,577 | An agent pipeline routinely moves text through places where a human name, an email address, a card number, or a medical record number does not belong. |
 | [Parallelization](parallelization.md) | established | 9,204 | An agentic pipeline built as a single sequential chain of LLM calls has one throughput limit, the wall-clock latency of the slowest single call multiplied by the number of calls ... |

--- a/patterns/17-ai-agentic/late-chunking.md
+++ b/patterns/17-ai-agentic/late-chunking.md
@@ -255,47 +255,52 @@ Five participants, named by the role each plays in the pipeline.
 ## 6. ASCII structure diagram
 
 ```
-NAIVE / EARLY CHUNKING (chunk first, embed each chunk alone)
+Naive / early chunking, chunk first, embed each alone
 
-  Document text
-       |
-       v
-  +-----------+     +---------+   +---------+   +---------+
-  |  Chunker  | --> | Chunk 1 |   | Chunk 2 |   | Chunk 3 |
-  +-----------+     +---------+   +---------+   +---------+
-                         |             |             |
-                         v             v             v
-                   +----------+  +----------+  +----------+
-                   | Encoder  |  | Encoder  |  | Encoder  |   <- 3 separate
-                   | (call 1) |  | (call 2) |  | (call 3) |      calls, no
-                   +----------+  +----------+  +----------+      shared context
-                         |             |             |
-                         v             v             v
-                     [ v1 ]        [ v2 ]        [ v3 ]
++---------------+
+| Document text |
++---------------+
+     v
++---------+
+| Chunker |
++---------+
+     | splits into
+     v
++---------+
+| Chunk 1 |
++---------+
++---------+
+| Chunk 2 |
++---------+
++---------+
+| Chunk 3 |
++---------+
+     | each chunk to its own Encoder call, no shared
+     | context between the three calls
+     v
+v1, v2, v3, three vectors, each blind to the others
 
 
-LATE CHUNKING (embed whole document once, chunk the token vectors after)
+Late chunking, embed the whole document once, then
+chunk the token vectors after
 
-  Document text
-       |
-       v
-  +--------------------------------------------------------+
-  |                 Long-context Encoder                   |
-  |             (single call, full attention)               |
-  +--------------------------------------------------------+
-       |
-       v
-  Token vectors:  [t1][t2][t3][t4][t5][t6][t7][t8][t9][t10]
-                    \___span1___/  \___span2___/  \_span3_/
-                        |               |              |
-                        v               v              v
-                   mean-pool       mean-pool       mean-pool
-                        |               |              |
-                        v               v              v
-                     [ v1' ]         [ v2' ]        [ v3' ]
++---------------+
+| Document text |
++---------------+
+     v
++------------------------------------------------------------------------+
+| Long-context Encoder, one call, full attention over the whole document |
++------------------------------------------------------------------------+
+     | produces token vectors t1 through t10
+     v
+span1 = t1..t4, span2 = t5..t7, span3 = t8..t10
+     | mean-pool each span
+     v
+v1', v2', v3'
 
-  Every t(i) above already attended across all 10 tokens, so
-  v1', v2', v3' each carry context that v1, v2, v3 above could not.
+Every token above already attended across all ten
+tokens, so v1', v2', v3' each carry context that v1,
+v2, v3 above could not.
 ```
 
 ## 7. Dynamics

--- a/patterns/24-stream-processing/README.md
+++ b/patterns/24-stream-processing/README.md
@@ -2,7 +2,7 @@
 
 Origin. Dataflow model, Kafka documentation
 
-7 entries, 41,952 words, 1 more planned, 8 total when the family is complete. Every entry carries all 18
+7 entries, 41,933 words, 1 more planned, 8 total when the family is complete. Every entry carries all 18
 dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 
 ## Stream Processing
@@ -12,7 +12,7 @@ dimensions from [the entry contract](../../docs/ENTRY-TEMPLATE.md).
 | [Dead-Letter Topic](dead-letter-topic.md) | established | 4,634 | KIP-298's own motivation states the problem this entry's stream-native variant answers directly. |
 | [Event-Time Processing](event-time-processing.md) | established | 8,516 | The Dataflow paper states the root cause directly. |
 | [Exactly-Once Processing](exactly-once-processing.md) | canonical | 4,481 | A stream processor that crashes mid-batch and restarts will, by default, reprocess whatever it had not yet acknowledged. |
-| [Replayable Log](replayable-log.md) | canonical | 4,185 | A traditional message queue removes a message once it has been consumed. |
+| [Replayable Log](replayable-log.md) | canonical | 4,166 | A traditional message queue removes a message once it has been consumed. |
 | [Stream Backpressure](stream-backpressure.md) | established | 4,617 | In a single-process reactive pipeline the backpressure problem is a pair, one producer and one consumer, and a demand-signaling or buffer-based protocol between the two is ... |
 | [Stream-Table Duality](stream-table-duality.md) | established | 5,645 | Kafka's own documentation frames the problem as a first-class support gap a stream-processing technology must close, not a hypothetical. |
 | [Watermark](watermark.md) | established | 9,874 | A stream processing system that groups records by when they actually happened, not by when the system happened to receive them, faces a specific unanswerable-looking question. |

--- a/patterns/24-stream-processing/replayable-log.md
+++ b/patterns/24-stream-processing/replayable-log.md
@@ -139,23 +139,22 @@ would have read at the time.
 ## 6. ASCII structure diagram
 
 ```
-Partition (append-only log, growing right)
+Partition, an append-only log, growing left to right
 
- head                                                    tail
- (oldest, subject to retention)              (newest, producer appends here)
-   |                                                        |
-   v                                                        v
- +----+----+----+----+----+----+----+----+----+----+----+----+
- | 0  | 1  | 2  | 3  | 4  | 5  | 6  | 7  | 8  | 9  | 10 | 11 |  --> new records
- +----+----+----+----+----+----+----+----+----+----+----+----+
-             ^                        ^                  ^
-             |                        |                  |
-   Consumer Group B            Consumer Group A    Consumer Group C
-   offset 1, replaying         offset 8, caught up  offset 11, just joined
-   from near the start                              (auto.offset.reset=earliest
-                                                       would instead seek to 0)
+head, oldest, subject to retention
+tail, newest, producer appends here
 
-Three independent groups, three independent cursors, one unchanged log.
+records:  0  1  2  3  4  5  6  7  8  9  10  11
+                                              ^
+                                    new records land here
+
+Consumer Group B, offset 1, replaying from near the start
+Consumer Group A, offset 8, caught up
+Consumer Group C, offset 11, just joined
+  (auto.offset.reset=earliest would instead seek to 0)
+
+Three independent groups, three independent cursors, one
+unchanged log.
 ```
 
 ## 7. Dynamics


### PR DESCRIPTION
Batch 14, the final batch, of the ASCII-diagram width
remediation pass.

Seven entries redrawn so every diagram line stays under 78
columns, across families 08, 09, 10, 13, 16, 17, and 24.

- rate-limiting
- semaphore
- serverless-deployment
- signals
- lens
- late-chunking
- replayable-log

Multi-branch and horizontal-timeline layouts (an enforcement
pipeline fanning to admit or deny, a semaphore's wait set, two
parallel execution envs, a naive versus late chunking
comparison, a partition log with three consumer cursors) are
redrawn as vertical chains or compact inline sequences with the
branch or timeline relationship named in prose, the same
simplification used in batches 7 through 13.

This closes out the width-remediation pass. All 134 entries
originally flagged over 78 columns in the frozen Phase 2 audit
are now fixed across 14 PRs (batches 1 through 14).

Gates run clean. check-structure.py (884/884), check-family-names.py,
check-prose.py (925/925), markdownlint-cli2 0.23.2 (0 issues),
validate-refs.py --strict (every citation resolves), check-code.py
--strict (2826 compiled, 0 failed). gen-indexes.py regenerated all
affected family README.md tables.