### PR TITLE
feat(tools) activate Pass 5 historical proposal collision detection

### DIFF
--- a/tools/check-duplicates-test.py
+++ b/tools/check-duplicates-test.py
@@ -21,6 +21,7 @@ normalize_term = check_duplicates.normalize_term
 tokenize_text = check_duplicates.tokenize_text
 jaccard_similarity = check_duplicates.jaccard_similarity
 analyze_repository = check_duplicates.analyze_repository
+fetch_historical_proposals = check_duplicates.fetch_historical_proposals
 
 
 class TestCheckDuplicates(unittest.TestCase):
@@ -33,6 +34,30 @@ class TestCheckDuplicates(unittest.TestCase):
         self.assertEqual(normalize_term("Pipes and Filters"), "pipesandfilters")
         self.assertEqual(normalize_term("Rate Limiting"), "ratelimiting")
         self.assertEqual(normalize_term("Throttling"), "throttling")
+
+    def test_parenthetical_qualifiers_normalization(self):
+        self.assertEqual(
+            normalize_term("Producer-Consumer (Embedded)"), "producerconsumer"
+        )
+        self.assertEqual(
+            normalize_term("Repository Pattern (Mobile Offline-First)"),
+            "repository",
+        )
+        self.assertEqual(
+            normalize_term("Model-View-Intent (MVI)"),
+            normalize_term("Model-View-Intent"),
+        )
+
+    def test_distinct_near_neighbors(self):
+        self.assertNotEqual(
+            normalize_term("Rate Limiting"), normalize_term("Throttling")
+        )
+        self.assertNotEqual(
+            normalize_term("Circuit Breaker"), normalize_term("Bulkhead")
+        )
+        self.assertNotEqual(
+            normalize_term("Strangler Fig"), normalize_term("Branch by Abstraction")
+        )
 
     def test_tokenize_text(self):
         tokens = tokenize_text(
@@ -52,9 +77,7 @@ class TestCheckDuplicates(unittest.TestCase):
         self.assertEqual(jaccard_similarity(set(), {"b"}), 0.0)
         self.assertEqual(jaccard_similarity({"a", "b"}, {"a", "b"}), 1.0)
         self.assertEqual(jaccard_similarity({"a", "b"}, {"c", "d"}), 0.0)
-        self.assertAlmostEqual(
-            jaccard_similarity({"a", "b"}, {"a", "c"}), 1.0 / 3.0
-        )
+        self.assertAlmostEqual(jaccard_similarity({"a", "b"}, {"a", "c"}), 1.0 / 3.0)
 
     def test_jaccard_similarity_threshold_pruning(self):
         # 1 vs 10 elements cannot exceed 0.70 threshold (max 1/10 = 0.10)
@@ -63,9 +86,7 @@ class TestCheckDuplicates(unittest.TestCase):
         self.assertEqual(jaccard_similarity(s1, s2, threshold=0.70), 0.0)
         # Without threshold constraint, 1 vs 10 evaluates normally
         s1_with_overlap = {"item_0"}
-        self.assertAlmostEqual(
-            jaccard_similarity(s1_with_overlap, s2), 1.0 / 10.0
-        )
+        self.assertAlmostEqual(jaccard_similarity(s1_with_overlap, s2), 1.0 / 10.0)
 
     def test_analyze_repository(self):
         queue_file = ROOT / "docs" / "AUTHORING-QUEUE.json"
@@ -73,6 +94,34 @@ class TestCheckDuplicates(unittest.TestCase):
         self.assertGreater(results["published_count"], 0)
         self.assertGreater(results["queue_count"], 0)
         self.assertIsInstance(results["collisions"], list)
+
+    def test_historical_proposal_detection(self):
+        history = fetch_historical_proposals()
+        self.assertIsInstance(history, list)
+        queue_file = ROOT / "docs" / "AUTHORING-QUEUE.json"
+        results = analyze_repository(queue_file)
+        self.assertIsInstance(results["collisions"], list)
+
+    def test_historical_proposal_collision_mock(self):
+        fake_history = [
+            {
+                "path": "patterns/24-stream-processing/old-windowing-attempt.md",
+                "slug": "windowing",
+            }
+        ]
+        original_fetch = check_duplicates.fetch_historical_proposals
+        check_duplicates.fetch_historical_proposals = lambda: fake_history
+        try:
+            queue_file = ROOT / "docs" / "AUTHORING-QUEUE.json"
+            results = analyze_repository(queue_file)
+            historical_collisions = [
+                c
+                for c in results["collisions"]
+                if c.get("type") == "HISTORICAL_PROPOSAL_COLLISION"
+            ]
+            self.assertGreater(len(historical_collisions), 0)
+        finally:
+            check_duplicates.fetch_historical_proposals = original_fetch
 
 
 if __name__ == "__main__":

--- a/tools/check-duplicates.py
+++ b/tools/check-duplicates.py
@@ -23,14 +23,51 @@ PATTERNS_DIR = ROOT / "patterns"
 QUEUE_FILE = ROOT / "docs" / "AUTHORING-QUEUE.json"
 
 STOPWORDS = {
-    "a", "an", "and", "are", "as", "at", "be", "by", "for", "from", "has", "he",
-    "in", "is", "it", "its", "of", "on", "that", "the", "to", "was", "were",
-    "will", "with", "or", "not", "this", "but", "they", "have", "had", "which"
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "at",
+    "be",
+    "by",
+    "for",
+    "from",
+    "has",
+    "he",
+    "in",
+    "is",
+    "it",
+    "its",
+    "of",
+    "on",
+    "that",
+    "the",
+    "to",
+    "was",
+    "were",
+    "will",
+    "with",
+    "or",
+    "not",
+    "this",
+    "but",
+    "they",
+    "have",
+    "had",
+    "which",
 }
 
 GENERIC_PATTERN_TERMS = {
-    "architecture", "pattern", "patterns", "technique", "smell",
-    "framework", "system", "design", "model"
+    "architecture",
+    "pattern",
+    "patterns",
+    "technique",
+    "smell",
+    "framework",
+    "system",
+    "design",
+    "model",
 }
 
 
@@ -38,6 +75,7 @@ def normalize_term(term: str) -> str:
     """Normalize names/aliases: lowercase, strip generic suffixes/stopwords, remove non-alphanumeric."""
     s = term.lower().strip()
     s = re.sub(r"'s\b", "", s)
+    s = re.sub(r"\(.*?\)", "", s)
     words = [w for w in re.split(r"\W+", s) if w and w not in GENERIC_PATTERN_TERMS]
     s_clean = "".join(words)
     return s_clean or re.sub(r"\W+", "", term.lower())
@@ -72,7 +110,9 @@ def extract_frontmatter_and_sections(filepath: Path) -> dict:
     family_match = re.search(r"^family\s*:\s*(.+)$", fm_text, re.MULTILINE)
 
     name = name_match.group(1).strip(" \"'\t") if name_match else filepath.stem
-    family = family_match.group(1).strip(" \"'\t") if family_match else filepath.parent.name
+    family = (
+        family_match.group(1).strip(" \"'\t") if family_match else filepath.parent.name
+    )
 
     aliases = []
     if aliases_match:
@@ -102,7 +142,12 @@ def extract_frontmatter_and_sections(filepath: Path) -> dict:
     for k, v in sec_combined.items():
         if "problem" in k or "context" in k:
             problem_text += "\n" + v
-        if "structure" in k or "dynamics" in k or "implementation" in k or "mechanism" in k:
+        if (
+            "structure" in k
+            or "dynamics" in k
+            or "implementation" in k
+            or "mechanism" in k
+        ):
             mechanism_text += "\n" + v
 
     problem_tokens = tokenize_text(problem_text)
@@ -124,7 +169,9 @@ def fetch_historical_proposals() -> list[dict]:
     history = []
     try:
         cmd = ["git", "log", "--all", "--name-status", "--oneline"]
-        out = subprocess.run(cmd, capture_output=True, text=True, cwd=ROOT, check=False).stdout
+        out = subprocess.run(
+            cmd, capture_output=True, text=True, cwd=ROOT, check=False
+        ).stdout
         for line in out.splitlines():
             parts = line.split("\t")
             if len(parts) >= 2 and parts[0] in {"A", "M"}:
@@ -138,7 +185,8 @@ def fetch_historical_proposals() -> list[dict]:
 
 def analyze_repository(queue_path: Path) -> dict:
     published_files = [
-        p for p in PATTERNS_DIR.rglob("*.md")
+        p
+        for p in PATTERNS_DIR.rglob("*.md")
         if p.name.lower() not in {"readme.md", "index.md"}
     ]
     published = [extract_frontmatter_and_sections(f) for f in published_files]
@@ -174,15 +222,17 @@ def analyze_repository(queue_path: Path) -> dict:
             if norm in published_norm_map:
                 for pub in published_norm_map[norm]:
                     if pub["path"] != q_path:
-                        collisions.append({
-                            "type": "QUEUE_VS_PUBLISHED",
-                            "queue_path": q_path,
-                            "published_path": pub["path"],
-                            "matched_term": term,
-                            "normalized_key": norm,
-                            "queue_name": q_name,
-                            "published_name": pub["name"],
-                        })
+                        collisions.append(
+                            {
+                                "type": "QUEUE_VS_PUBLISHED",
+                                "queue_path": q_path,
+                                "published_path": pub["path"],
+                                "matched_term": term,
+                                "normalized_key": norm,
+                                "queue_name": q_name,
+                                "published_name": pub["name"],
+                            }
+                        )
 
     # Published vs Published Semantic Similarity Check
     semantic_collisions = []
@@ -195,17 +245,55 @@ def analyze_repository(queue_path: Path) -> dict:
             p2 = published[j]
             prob_sim = jaccard_similarity(t1_prob, p2["problem_tokens"], threshold)
             if prob_sim > threshold:
-                mech_sim = jaccard_similarity(t1_mech, p2["mechanism_tokens"], threshold)
+                mech_sim = jaccard_similarity(
+                    t1_mech, p2["mechanism_tokens"], threshold
+                )
                 if mech_sim > threshold:
-                    semantic_collisions.append({
-                        "type": "PUBLISHED_SEMANTIC_DUPLICATE",
-                        "path1": p1["path"],
-                        "path2": p2["path"],
-                        "problem_similarity": prob_sim,
-                        "mechanism_similarity": mech_sim,
-                    })
+                    semantic_collisions.append(
+                        {
+                            "type": "PUBLISHED_SEMANTIC_DUPLICATE",
+                            "path1": p1["path"],
+                            "path2": p2["path"],
+                            "problem_similarity": prob_sim,
+                            "mechanism_similarity": mech_sim,
+                        }
+                    )
 
     history = fetch_historical_proposals()
+    published_paths = {p["path"] for p in published}
+
+    # Map historical terms for entries not currently published
+    history_norm_map: dict[str, list[dict]] = {}
+    for h in history:
+        if h["path"] not in published_paths:
+            norm = normalize_term(h["slug"])
+            if norm:
+                history_norm_map.setdefault(norm, []).append(h)
+
+    # Queue vs Historical Proposal Collisions (Pass 5)
+    for q in queue:
+        q_path = q.get("path", "")
+        q_slug = q.get("slug", "")
+        q_name = q.get("name", "")
+        q_aliases = q.get("aliases", [])
+
+        q_terms = [q_name, q_slug] + list(q_aliases)
+        for term in q_terms:
+            norm = normalize_term(term)
+            if norm in history_norm_map:
+                for hist in history_norm_map[norm]:
+                    if hist["path"] != q_path:
+                        collisions.append(
+                            {
+                                "type": "HISTORICAL_PROPOSAL_COLLISION",
+                                "queue_path": q_path,
+                                "historical_path": hist["path"],
+                                "matched_term": term,
+                                "normalized_key": norm,
+                                "queue_name": q_name,
+                                "historical_slug": hist["slug"],
+                            }
+                        )
 
     return {
         "published_count": len(published),
@@ -218,12 +306,20 @@ def analyze_repository(queue_path: Path) -> dict:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Software Pattern Duplicate Detector")
-    parser.add_argument("--check", action="store_true", help="Run duplicate detection check")
-    parser.add_argument("--strict", action="store_true", help="Fail with non-zero exit code on queue/published duplicate collision")
+    parser.add_argument(
+        "--check", action="store_true", help="Run duplicate detection check"
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail with non-zero exit code on queue/published duplicate collision",
+    )
     args = parser.parse_args()
 
     results = analyze_repository(QUEUE_FILE)
-    print(f"Analyzed {results['published_count']} published entries, {results['queue_count']} queue entries, {results['historical_count']} historic commits.")
+    print(
+        f"Analyzed {results['published_count']} published entries, {results['queue_count']} queue entries, {results['historical_count']} historic commits."
+    )
 
     collisions = results["collisions"]
     semantic = results["semantic_collisions"]
@@ -232,15 +328,27 @@ def main() -> int:
         print(f"\nFound {len(collisions)} potential duplicate/collision pairs:")
         seen = set()
         for c in collisions:
-            pair_key = (c["queue_path"], c["published_path"], c["normalized_key"])
-            if pair_key not in seen:
-                seen.add(pair_key)
-                print(f"  [QUEUE COLLISION] {c['queue_path']} ({c['queue_name']}) <-> Published: {c['published_path']} ({c['published_name']}) via '{c['matched_term']}'")
+            if c.get("type") == "HISTORICAL_PROPOSAL_COLLISION":
+                pair_key = (c["queue_path"], c["historical_path"], c["normalized_key"])
+                if pair_key not in seen:
+                    seen.add(pair_key)
+                    print(
+                        f"  [HISTORICAL COLLISION] {c['queue_path']} ({c['queue_name']}) <-> Historic: {c['historical_path']} ({c['historical_slug']}) via '{c['matched_term']}'"
+                    )
+            else:
+                pair_key = (c["queue_path"], c["published_path"], c["normalized_key"])
+                if pair_key not in seen:
+                    seen.add(pair_key)
+                    print(
+                        f"  [QUEUE COLLISION] {c['queue_path']} ({c['queue_name']}) <-> Published: {c['published_path']} ({c['published_name']}) via '{c['matched_term']}'"
+                    )
 
     if semantic:
         print(f"\nFound {len(semantic)} high semantic overlap published pairs:")
         for s in semantic:
-            print(f"  [SEMANTIC SIMILARITY] {s['path1']} <-> {s['path2']} (Prob: {s['problem_similarity']:.2f}, Mech: {s['mechanism_similarity']:.2f})")
+            print(
+                f"  [SEMANTIC SIMILARITY] {s['path1']} <-> {s['path2']} (Prob: {s['problem_similarity']:.2f}, Mech: {s['mechanism_similarity']:.2f})"
+            )
 
     if args.strict or args.check:
         # Require clean check if strict is set or if specified


### PR DESCRIPTION
## Summary

Applies the `check-duplicates.py` half of PR #268, adapted onto
current main. The original branch predated the `check-claims.py`
test-infrastructure work (#439) and the jaccard-similarity threshold
pruning that has since landed on `check-duplicates-test.py`, so the
diff could not apply cleanly. This branch carries forward the same
intended feature, reviewed and re-verified against the current file
shapes.

Wires the historical-proposal collision pass. `fetch_historical_proposals`
already gathered commit history for entries that were once proposed
and never published, but `analyze_repository` never checked the queue
against it. Now a queue entry whose name, slug, or any alias
normalizes to match an unpublished historical proposal's slug surfaces
as a `HISTORICAL_PROPOSAL_COLLISION`, printed under a distinct
`[HISTORICAL COLLISION]` label so it reads differently from a live
queue-vs-published collision.

`normalize_term` also now strips a trailing parenthetical qualifier
before the rest of normalization runs, so `Producer-Consumer (Embedded)`
and a bare `Producer-Consumer` correctly collide while `Rate Limiting`
and `Throttling` correctly stay distinct.

## Verification

- `python3 tools/check-duplicates-test.py`. 9 of 9 tests pass (5
  existing, 4 new)
- Ran the checker live against the real repository. correctly still
  finds the one genuine queue-vs-published collision (`windowing` vs
  `virtual-list`) and reports zero historical collisions, since none
  of the 3 remaining queue entries match anything in the fetched
  history right now
- The mocked collision test uses a fake historical entry whose slug
  matches a real current queue entry (`windowing`), confirmed to
  actually trigger a `HISTORICAL_PROPOSAL_COLLISION` rather than
  trivially passing against an empty result
- `py_compile` and `ruff check` both clean on both touched files

## Test plan

- [x] Unit tests pass
- [x] Live run against the real queue and history confirmed correct
- [x] Mock test verified to actually exercise the new code path
