### PR TITLE
fix(license): correct prior-licence placeholder to CC BY 4.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -14,9 +14,9 @@ is issued as a new version and this text remains reachable permanently.
 
 PRIOR LICENCE NOTICE
 --------------------
-This repository was previously distributed under custom.
+This repository was previously distributed under CC BY 4.0.
 That grant is irrevocable for every version released under it.
-Anyone who obtained an earlier release keeps their custom rights
+Anyone who obtained an earlier release keeps their CC BY 4.0 rights
 in perpetuity. This licence governs releases from 2026-08-24 onward.
 
 SUMMARY OF TERMS


### PR DESCRIPTION
Fixes an unfilled placeholder in LICENSE that shipped with the ORA 1.0 adoption. The PRIOR LICENCE NOTICE section read "previously distributed under custom" and "keeps their custom rights". "custom" is not a license name, it is a template placeholder that was never filled in.

The repo's actual prior license, stated correctly everywhere else in ATTRIBUTION.md and in the ORA 1.0 adoption PR body, is CC BY 4.0. This PR makes the LICENSE file say the same thing.

Local gates run clean before this push. The prose gate passes 931 of 931 files. The structure gate passes 890 of 890 entries. The refs validator confirms all 4995 citations resolve.

Suggested labels. bug, documentation
