### PR TITLE
Point the README at the licence version the repo actually carries

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ version.
 4. Every claim cited. Every cited URL verified on the day you submit.
 5. Production usage names a real system with a real source.
 
-Contributions are licensed under the same OpenRoots Agent License 1.0 as
+Contributions are licensed under the same OpenRoots Agent License 2.3 as
 the rest of this repository.
 
 ### Contributing with an AI coding agent
@@ -539,9 +539,9 @@ not claim it.
 ## License
 
 Content is licensed under the
-[OpenRoots Agent License 1.0](LICENSE), effective 2026-08-24. The
+[OpenRoots Agent License 2.3](LICENSE), effective 2026-08-27. The
 [NOTICE](NOTICE) file carries the short summary, the canonical legal text
-lives at [openroots.org](https://openroots.org/licenses/ora/1.0).
+lives at [openroots.org](https://openroots.org/licenses/ora/2.3).
 
 Free and unconditional at or below two million US dollars in annual
 revenue, and for any individual, nonprofit, school, or government body.
@@ -553,6 +553,6 @@ this repository's prior license keeps those rights permanently, that
 grant does not change.
 
 ```text
-"Patterns" by Mirza Iqbal, OpenRoots Agent License 1.0
+"Patterns" by Mirza Iqbal, OpenRoots Agent License 2.3
 https://github.com/mjmirza/patterns
 ```


### PR DESCRIPTION
The LICENSE moved to 2.3 but the README still named 1.0 in four places, including the deed URL and the attribution line a reuser is meant to copy.

A repo whose licence file and README disagree gives a reader two different answers about the terms, which is worse than either being out of date on its own.

Found by a sweep across all twelve repos that moved to 2.3. This was the only one carrying a surviving reference.

Suggested labels

- licence, docs