### PR TITLE
Adopt the OpenRoots Agent License 2.3

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5,21 +5,13 @@ Canonical text: https://openroots.org/licenses/ora/2.3/legalcode.txt
 Plain summary:  https://openroots.org/licenses/ora/2.3
 SPDX:           LicenseRef-OpenRoots-ORA-2.3
 
-Effective:      2026-08-27
+Effective:      see the release this file accompanies
 Term:           Permanent. This release does not convert to another
                 licence by lapse of time.
 
 This licence is one fixed text, adopted word for word. The canonical
 version lives at the address above and is never edited. A correction
 is issued as a new version and this text remains reachable permanently.
-
-EARLIER RELEASES KEEP THEIR EARLIER TERMS
------------------------------------------
-This repository previously carried OpenRoots Agent License 1.0.
-Section 7.2 attaches a version to the release it accompanied, so every
-release distributed under 1.0 stays under 1.0 permanently,
-including any sunset conversion that version granted. This file governs
-releases made from its own effective date onward.
 
 SUMMARY OF TERMS
 ----------------

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ A short instruction that works in `AGENTS.md`, `CLAUDE.md`, a Cursor rule, or
 ```
 # Patterns decision reference
 
+[![OpenRoots ORA 2.3](https://openroots.org/badge/ora.svg)](https://openroots.org/licenses/ora/2.3)
+
 Before proposing an architecture, a retry strategy, a data flow, or a fix
 for a design smell, consult .patterns/docs/BY-PROBLEM.md and the relevant
 family under .patterns/patterns/ for the named pattern that covers this


### PR DESCRIPTION
Brings this repository onto the OpenRoots Agent License 2.3, the same
instrument now carried across the public set, and adds the licence badge under
the heading.

The LICENSE file is a pointer, not a copy. The canonical text lives at
openroots.org and is never edited, so a correction is issued as a new version
rather than by editing text already relied on.

Generated from the source of truth rather than typed, so the threshold, the
rate and the cap cannot drift from what the site publishes.
